### PR TITLE
add test-kitchen dependencies. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+exp.*
+.kitchen
+Berksfile.lock
+.kitchen.local.yml
+shared_test_repo/
+.librarian/
+.tmp/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,47 @@
+---
+
+driver:
+  name: vagrant
+
+provisioner:
+  name: puppet_apply
+  manifests_path: manifests
+  modules_path: modules
+  hiera_data_path: hieradata
+  manifest: site.pp
+  test_repo_uri: "https://github.com/TelekomLabs/tests-os-hardening.git"
+
+platforms:
+- name: ubuntu-12.04
+  driver_config:
+    box: opscode-ubuntu-12.04
+    box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-12.04_chef-provisionerless.box
+
+- name: centos-6.4
+  driver_config:
+    box: opscode-centos-6.4
+    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
+
+- name: centos-6.5
+  driver_config:
+     box: opscode-centos-6.5
+     box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.5_chef-provisionerless.box
+
+- name: oracle-6.4
+  driver_config:
+    box: oracle-6.4
+    box_url: https://dl.dropbox.com/sh/yim9oyqajopoiqs/G-XIEmQJMb/oracle64-64.box
+
+- name: debian-squezze-6
+  driver_config:
+    box: debian-squezze-6
+    box_url: http://public.sphax3d.org/vagrant/squeeze64.box
+
+- name: debian-wheezy-7
+  driver_config:
+    box: debian-wheezy-7
+    box_url: https://dl.dropboxusercontent.com/s/cd583cuf0mbcix7/debian-wheezy-64-chef.box
+
+suites:
+  - name: default
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source 'https://rubygems.org'
+
+group :integration do
+  gem 'test-kitchen'
+  gem 'kitchen-vagrant'
+  gem 'kitchen-openstack'
+  gem 'kitchen-puppet', '= 0.0.8'
+  gem 'librarian-puppet'
+  gem 'puppet'
+  gem 'kitchen-sharedtests'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,85 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    builder (3.2.2)
+    excon (0.33.0)
+    facter (2.0.1)
+      CFPropertyList (~> 2.2.6)
+    fog (1.22.0)
+      fog-brightbox
+      fog-core (~> 1.21, >= 1.21.1)
+      fog-json
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-brightbox (0.0.2)
+      fog-core
+      fog-json
+    fog-core (1.22.0)
+      builder
+      excon (~> 0.33)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-json (1.0.0)
+      multi_json (~> 1.0)
+    formatador (0.2.4)
+    git (1.2.6)
+    hiera (1.3.2)
+      json_pure
+    highline (1.6.21)
+    json (1.8.1)
+    json_pure (1.8.1)
+    kitchen-openstack (1.4.0)
+      fog (~> 1.18)
+      test-kitchen (~> 1.1)
+      unf
+    kitchen-puppet (0.0.8)
+    kitchen-sharedtests (0.0.1)
+      git
+    kitchen-vagrant (0.15.0)
+      test-kitchen (~> 1.0)
+    librarian (0.1.2)
+      highline
+      thor (~> 0.15)
+    librarian-puppet (1.0.2)
+      json
+      librarian (>= 0.1.2)
+    mime-types (2.2)
+    mini_portile (0.6.0)
+    mixlib-shellout (1.4.0)
+    multi_json (1.10.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.1)
+    nokogiri (1.6.2.1)
+      mini_portile (= 0.6.0)
+    puppet (3.5.1)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+      rgen (~> 0.6.5)
+    rgen (0.6.6)
+    safe_yaml (1.0.3)
+    test-kitchen (1.2.1)
+      mixlib-shellout (~> 1.2)
+      net-scp (~> 1.1)
+      net-ssh (~> 2.7)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    thor (0.19.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kitchen-openstack
+  kitchen-puppet (= 0.0.8)
+  kitchen-sharedtests
+  kitchen-vagrant
+  librarian-puppet
+  puppet
+  test-kitchen

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+#^syntax detection
+
+forge "http://forge.puppetlabs.com"
+
+# use dependencies defined in Modulefile
+modulefile
+
+mod 'hardening/os_hardening'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,0 +1,10 @@
+FORGE
+  remote: http://forge.puppetlabs.com
+  specs:
+    hardening/os_hardening (0.1.1)
+      puppetlabs/stdlib (= 3.2.1)
+    puppetlabs/stdlib (3.2.1)
+
+DEPENDENCIES
+  hardening/os_hardening (>= 0)
+

--- a/Thorfile
+++ b/Thorfile
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+require 'bundler'
+require 'bundler/setup'
+require 'kitchen_sharedtests'
+require 'kitchen/sharedtests_thor_tasks'
+
+Kitchen::SharedtestsThorTasks.new

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,1 @@
+class { 'os_hardening': }


### PR DESCRIPTION
running the tests with thor for now. 

there is still an open issue to actually use the current repo and not module pushed to puppetlabs but this MR allows for running the shared tests against the current module version which gives us at least some feedback.
