### PR TITLE
improvement: only remove suid/sgid if necessary

### DIFF
--- a/manifests/blacklist_files.pp
+++ b/manifests/blacklist_files.pp
@@ -2,6 +2,10 @@
 define blacklist_files {
   exec{ "remove suid/sgid bit from ${name}":
     command => "/bin/chmod ug-s ${name}",
-    onlyif  => "/usr/bin/test -f ${name}",
+    # the following checks if we are operating on a file
+    # and if this file has either SUID or SGID bits set
+    # it reads:
+    # (isFile(x) && isSuid(x)) || (isFile(x) && isSgid(x))
+    onlyif  => "/usr/bin/test -f ${name} -a -u ${name} -o -f ${name} -a -g ${name}",
   }
 }


### PR DESCRIPTION
Added a check that makes sure that we are actually operating on a file and that this file has either SUID or SGID bits set. Only then will they be removed.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
