### PR TITLE
bugfix: remove module lockdown for now

### DIFF
--- a/templates/sysctl.conf.erb
+++ b/templates/sysctl.conf.erb
@@ -115,7 +115,7 @@ net.ipv4.conf.default.send_redirects = 0
 # ------
 
 # This settings controls how the kernel behaves towards module changes at runtime. Setting to 1 will disable module loading at runtime.
-kernel.modules_disabled = <%= @enable_module_loading ? 0 : 1 %>
+#kernel.modules_disabled = <%= @enable_module_loading ? 0 : 1 %>
 
 # Magic Sysrq should be disabled, but can also be set to a safe value if so desired for physical machines. It can allow a safe reboot if the system hangs and is a 'cleaner' alternative to hitting the reset button.
 # The following values are permitted:


### PR DESCRIPTION
we need to boil down the supported operating systems to have this in, otherwise it blocks sysctl reloads

Signed-off-by: Dominik Richter dominik.richter@gmail.com
