### PR TITLE
bugfix: add missing thias/sysctl dependency to modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/TelekomLabs/puppet-os-hardening'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '3.2.1'
+dependency 'thias/sysctl', '0.3.1'


### PR DESCRIPTION
since we still require modulefile due to kitchen tests, the dependencies must be fixed to be the same for metadata.json and Modulefile (which puppet ignores).

Signed-off-by: Dominik Richter dominik.richter@gmail.com
