### PR TITLE
Remove stdlib version dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,5 +8,5 @@ description 'Configures the base OS with hardening'
 project_page 'https://github.com/TelekomLabs/puppet-os-hardening'
 
 ## Add dependencies, if any:
-dependency 'puppetlabs/stdlib', '3.2.1'
+dependency 'puppetlabs/stdlib'
 dependency 'thias/sysctl', '0.3.1'


### PR DESCRIPTION
Based on my (relatively limited) testing, this module works with puppetlabs-stdlib v4.2.2. This was only tested against Ubuntu 12.04.

Removing the 3.2.1 dependency avoids conflicts with other modules that require newer versions.
