### PR TITLE
remove puppet 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: ruby
 bundler_args: --without development integration openstack
 env:
   - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.0.0"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
 matrix:
@@ -16,5 +15,3 @@ matrix:
       env: PUPPET_VERSION="~> 2.7.0"
     - rvm: 2.0.0
       env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.0.0"


### PR DESCRIPTION
As decided here: https://github.com/TelekomLabs/tests-os-hardening/pull/16

Signed-off-by: Dominik Richter dominik.richter@gmail.com
