### PR TITLE
feature: add back support for puppet 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: ruby
 bundler_args: --without development integration openstack
 env:
   - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.4.3"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.6.0"
 matrix:


### PR DESCRIPTION
Since trusty has puppet 3.4 in its package repository, we need to support it. Add it back.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
