### PR TITLE
login.defs.erb: set LOG_OK_LOGINS = "no", correct ENV_PATH syntax

### DIFF
--- a/templates/login.defs.erb
+++ b/templates/login.defs.erb
@@ -30,7 +30,7 @@ FAILLOG_ENAB    yes
 LOG_UNKFAIL_ENAB  no
 
 # Enable logging of successful logins
-LOG_OK_LOGINS   yes
+LOG_OK_LOGINS   no
 
 # Enable "syslog" logging of su activity - in addition to sulog file logging.
 SYSLOG_SU_ENAB    yes
@@ -56,7 +56,7 @@ HUSHLOGIN_FILE  .hushlogin
 
 # *REQUIRED*: The default PATH settings, for superuser and normal users. (they are minimal, add the rest in the shell startup files)
 ENV_SUPATH  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV_PATH  PATH=/usr/local/bin:/usr/bin:/bin<% if not @additional_user_paths.empty? %><%= @additional_user_paths %><% end %>
+ENV_PATH  PATH=/usr/local/bin:/usr/bin:/bin<% if not @additional_user_paths.empty? %>:<%= @additional_user_paths %><% end %>
 
 # Terminal permissions
 # --------------------


### PR DESCRIPTION
LOG_OK_LOGINS is set to "no" by default in Debian which appears to be the upstream source of this template. All values should be default unless they can be configured by the module.

Add separator for ENV_PATH otherwise the first value in "additional_user_paths" will not be separated from the default value in the file.
