### PR TITLE
Remove link following in minimize_access file resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,14 +13,12 @@ group :test do
   gem 'rake'
   # bugfix for ruby 1.8, puppet+rspec interplay
   # https://github.com/rspec/rspec-core/issues/1864
-  if RUBY_VERSION.start_with? '1.8'
-    gem 'rspec', '~> 3.1.0',     :require => false
-  end
+  gem 'rspec', '~> 3.1.0', :require => false if RUBY_VERSION.start_with? '1.8'
   gem 'rspec-puppet'
   # avoid NoMethodError: private method `clone' called for #<RuboCop::Cop::CopStore:0x00000104e286c8>
   gem 'puppetlabs_spec_helper', :git => 'https://github.com/ehaselwanter/puppetlabs_spec_helper'
   gem 'puppet-lint'
-  gem 'rubocop',    '~> 0.31' if RUBY_VERSION > '1.9.2'
+  gem 'rubocop', '~> 0.31' if RUBY_VERSION > '1.9.2'
 end
 
 group :development do

--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -29,7 +29,6 @@ class os_hardening::minimize_access (
   # this prevents changing any system-wide command from normal users
   file { $folders:
     ensure  => 'directory',
-    links   => 'follow',
     mode    => 'go-w',
     recurse => true,
   }


### PR DESCRIPTION
This patch resolves Issue: https://github.com/hardening-io/puppet-os-hardening/issues/60

From this page, Ubuntu containing the symlink ```/usr/bin/X11 -> .``` is by design:
http://askubuntu.com/questions/191654/why-are-there-infinitely-many-x11-subdirectories-in-usr-bin-x11

This patch removes ```links => follow``` to prevent recursing down links.   The caller defines the directories to apply the File resource to, so defining the scope.  Any files lying in directories outside this scope should not be touched, covering symlink targets outside.

