### PR TITLE
Changes folders resource title to prevent conflicts.

### DIFF
--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -27,7 +27,7 @@ class os_hardening::minimize_access (
 
   # remove write permissions from path folders ($PATH) for all regular users
   # this prevents changing any system-wide command from normal users
-  file { $folders:
+  file { "os_hardening_${folders}":
     ensure  => 'directory',
     links   => 'follow',
     mode    => 'go-w',


### PR DESCRIPTION
Puppet Enterprise (at least version 2016.1.1) manages
/usr/local/bin with that resource title. Changing
the resource title to prefix os_hardening fixes the issue.

os_hardening_${folders}