### PR TITLE
Set SYS_UID_MIN/MAX and SYS_GID_MIN/MAX

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
 fixtures:
   repositories:
     sysctl: https://github.com/thias/puppet-sysctl.git
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -20,8 +19,6 @@ matrix:
       env: PUPPET_VERSION="~> 2.7.0"
     - rvm: 2.1.0
       env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 4.0.0"
     - rvm: 1.9.3
       env: PUPPET_VERSION="~> 4.0.0"
     - rvm: 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 source 'https://rubygems.org'
 
 puppetversion = ENV['PUPPET_VERSION']

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Guardfile
 
 guard 'rake', :task => 'lint' do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 #!/usr/bin/env rake
-# encoding: utf-8
 
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppetlabs_spec_helper/rake_tasks'

--- a/Thorfile
+++ b/Thorfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'bundler'
 require 'bundler/setup'
 require 'kitchen_sharedtests'

--- a/lib/facter/retrieve_system_users.rb
+++ b/lib/facter/retrieve_system_users.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Try to read UID_MIN from /etc/login.defs to caluclate SYS_UID_MAX
 # if that fails set some predefined values based on os_family fact.
 logindefs = '/etc/login.defs'

--- a/lib/puppet/parser/functions/combine_sugid_lists.rb
+++ b/lib/puppet/parser/functions/combine_sugid_lists.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # Copyright 2014, Deutsche Telekom AG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,8 +19,12 @@ class os_hardening(
   $password_min_age         = 7,
   $login_retries            = 5,
   $login_timeout            = 60,
-  $chfn_restrict            = '',
+  $chfn_restrict            = 'UNSET',
   $allow_login_without_home = false,
+  $sys_uid_min              = 100,
+  $sys_uid_max              = 999,
+  $sys_gid_min              = 100,
+  $sys_gid_max              = 999,
 
   $allow_change_user        = false,
   $ignore_users             = [],
@@ -59,6 +63,8 @@ class os_hardening(
   validate_bool($manage_pam_unix)
   validate_bool($enable_pw_history)
   validate_integer($pw_remember_last)
+  validate_array($extra_user_paths)
+  validate_string($additional_user_paths)
 
   # Prepare
   # -------
@@ -72,22 +78,14 @@ class os_hardening(
     $system_environment != 'docker'
     )
 
+  $additional_user_paths = join( $extra_user_paths, ':' )
 
   # Install
   # -------
   class {'os_hardening::limits':
     allow_core_dumps         => $allow_core_dumps,
   }
-  class {'os_hardening::login_defs':
-    extra_user_paths         => $extra_user_paths,
-    umask                    => $umask,
-    password_max_age         => $password_max_age,
-    password_min_age         => $password_min_age,
-    login_retries            => $login_retries,
-    login_timeout            => $login_timeout,
-    chfn_restrict            => $chfn_restrict,
-    allow_login_without_home => $allow_login_without_home,
-  }
+  class {'os_hardening::login_defs': }
   class {'os_hardening::minimize_access':
     allow_change_user => $allow_change_user,
     ignore_users      => $ignore_users,

--- a/manifests/login_defs.pp
+++ b/manifests/login_defs.pp
@@ -9,18 +9,7 @@
 #
 # Configures PAM
 #
-class os_hardening::login_defs (
-  $extra_user_paths = [],
-  $umask = '027',
-  $password_max_age = 60,
-  $password_min_age = 7,
-  $login_retries = 5,
-  $login_timeout = 60,
-  $chfn_restrict = '',
-  $allow_login_without_home = false,
-){
-  # prepare all variables
-  $additional_user_paths = join( $extra_user_paths, ':' )
+class os_hardening::login_defs {
 
   # set the file
   file {
@@ -29,6 +18,6 @@ class os_hardening::login_defs (
       content => template( 'os_hardening/login.defs.erb' ),
       owner   => 'root',
       group   => 'root',
-      mode    => '0400',
+      mode    => '0444',
   }
 }

--- a/spec/classes/login_defs_spec.rb
+++ b/spec/classes/login_defs_spec.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # Copyright 2014, Deutsche Telekom AG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,13 +21,13 @@ describe 'os_hardening' do
 
   context 'with default extra_user_paths empty' do
     it do
-      should contain_file('/etc/login.defs').with_content(/^ENV_PATH  PATH=\/usr\/local\/bin:\/usr\/bin:\/bin$/)
+      should contain_file('/etc/login.defs').with_content(%r{^ENV_PATH  PATH=/usr/local/bin:/usr/bin:/bin$})
     end
   end
   context 'with custom allow_login_without_home => true' do
-    let(:params) { { :extra_user_paths => [ '/opt/bin', '/foo/bin' ] } }
+    let(:params) { { :extra_user_paths => ['/opt/bin', '/foo/bin'] } }
     it do
-      should contain_file('/etc/login.defs').with_content(/^ENV_PATH  PATH=\/usr\/local\/bin:\/usr\/bin:\/bin:\/opt\/bin:\/foo\/bin$/)
+      should contain_file('/etc/login.defs').with_content(%r{^ENV_PATH  PATH=/usr/local/bin:/usr/bin:/bin:/opt/bin:/foo/bin$})
     end
   end
   context 'with default umask => 027' do
@@ -153,6 +151,4 @@ describe 'os_hardening' do
       should contain_file('/etc/login.defs').with_content(/^DEFAULT_HOME yes/)
     end
   end
-
-
 end

--- a/spec/classes/login_defs_spec.rb
+++ b/spec/classes/login_defs_spec.rb
@@ -1,0 +1,158 @@
+# encoding: utf-8
+#
+# Copyright 2014, Deutsche Telekom AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe 'os_hardening' do
+
+  it { should contain_class('os_hardening::login_defs') }
+
+  context 'with default extra_user_paths empty' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^ENV_PATH  PATH=\/usr\/local\/bin:\/usr\/bin:\/bin$/)
+    end
+  end
+  context 'with custom allow_login_without_home => true' do
+    let(:params) { { :extra_user_paths => [ '/opt/bin', '/foo/bin' ] } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^ENV_PATH  PATH=\/usr\/local\/bin:\/usr\/bin:\/bin:\/opt\/bin:\/foo\/bin$/)
+    end
+  end
+  context 'with default umask => 027' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^UMASK 027/)
+    end
+  end
+  context 'with custom umask => 720' do
+    let(:params) { { :umask => 720 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^UMASK 720/)
+    end
+  end
+  context 'with default password_max_age => 60' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^PASS_MAX_DAYS 60/)
+    end
+  end
+  context 'with custom password_max_age => 99' do
+    let(:params) { { :password_max_age => 99 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^PASS_MAX_DAYS 99/)
+    end
+  end
+  context 'with default password_min_age => 7' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^PASS_MIN_DAYS 7/)
+    end
+  end
+  context 'with custom password_min_age => 99' do
+    let(:params) { { :password_min_age => 99 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^PASS_MIN_DAYS 99/)
+    end
+  end
+  context 'with default sys_uid_min => 100' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_UID_MIN 100/)
+    end
+  end
+  context 'with custom sys_uid_min => 99' do
+    let(:params) { { :sys_uid_min => 99 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_UID_MIN 99/)
+    end
+  end
+  context 'with default sys_uid_max => 999' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_UID_MAX 999/)
+    end
+  end
+  context 'with custom sys_uid_max => 499' do
+    let(:params) { { :sys_uid_max => 499 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_UID_MAX 499/)
+    end
+  end
+  context 'with default sys_gid_min => 100' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_GID_MIN 100/)
+    end
+  end
+  context 'with custom sys_gid_min => 99' do
+    let(:params) { { :sys_gid_min => 99 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_GID_MIN 99/)
+    end
+  end
+  context 'with default sys_gid_max => 999' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_GID_MAX 999/)
+    end
+  end
+  context 'with custom sys_gid_max => 499' do
+    let(:params) { { :sys_gid_max => 499 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^SYS_GID_MAX 499/)
+    end
+  end
+  context 'with default login_retries => 5' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^LOGIN_RETRIES 5/)
+    end
+  end
+  context 'with custom login_retries => 10' do
+    let(:params) { { :login_retries => 10 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^LOGIN_RETRIES 10/)
+    end
+  end
+  context 'with default login_timeout => 60' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^LOGIN_TIMEOUT 60/)
+    end
+  end
+  context 'with custom login_timeout => 10' do
+    let(:params) { { :login_timeout => 10 } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^LOGIN_TIMEOUT 10/)
+    end
+  end
+  context 'with default chfn_restrict absent ' do
+    it do
+      should contain_file('/etc/login.defs').without_content(/^CHFN_RESTRICT/)
+    end
+  end
+  context 'with custom chfn_restrict => frwh' do
+    let(:params) { { :chfn_restrict => 'frwh' } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^CHFN_RESTRICT frwh/)
+    end
+  end
+  context 'with default allow_login_without_home => false' do
+    it do
+      should contain_file('/etc/login.defs').with_content(/^DEFAULT_HOME no/)
+    end
+  end
+  context 'with custom allow_login_without_home => true' do
+    let(:params) { { :allow_login_without_home => true } }
+    it do
+      should contain_file('/etc/login.defs').with_content(/^DEFAULT_HOME yes/)
+    end
+  end
+
+
+end

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-#
 # Copyright 2014, Deutsche Telekom AG
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +25,6 @@ end
 
 RSpec.configure do |c|
   c.default_facts = {
-    retrieve_system_users: 'root,bin,daemon,adm,lp,sync,shutdown',
+    retrieve_system_users: 'root,bin,daemon,adm,lp,sync,shutdown'
   }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,9 @@ RSpec.configure do |c|
   c.manifest_dir = File.join(fixture_path, 'manifests')
   c.environmentpath = File.expand_path(File.join(Dir.pwd, 'spec'))
 end
+
+RSpec.configure do |c|
+  c.default_facts = {
+    retrieve_system_users: 'root,bin,daemon,adm,lp,sync,shutdown',
+  }
+end

--- a/templates/login.defs.erb
+++ b/templates/login.defs.erb
@@ -1,21 +1,21 @@
 # Configuration control definitions for the login package.
-# 
+#
 # Three items must be defined:  `MAIL_DIR`, `ENV_SUPATH`, and `ENV_PATH`. If unspecified, some arbitrary (and possibly incorrect) value will be assumed.  All other items are optional - if not specified then the described action or option will be inhibited.
-# 
+#
 # Comment lines (lines beginning with `#`) and blank lines are ignored.
 #
 #-- Modified for Linux.  --marekm
 
 # *REQUIRED for useradd/userdel/usermod*
-# 
+#
 # Directory where mailboxes reside, _or_ name of file, relative to the home directory.  If you _do_ define `MAIL_DIR` and `MAIL_FILE`, `MAIL_DIR` takes precedence.
 # Essentially:
-# 
+#
 # * `MAIL_DIR` defines the location of users mail spool files (for mbox use) by appending the username to `MAIL_DIR` as defined below.
 # * `MAIL_FILE` defines the location of the users mail spool files as the fully-qualified filename obtained by prepending the user home directory before `$MAIL_FILE`
 #
 # *NOTE*: This is no more used for setting up users MAIL environment variable which is, starting from shadow 4.0.12-1 in Debian, entirely the job of the pam_mail PAM modules.
-# 
+#
 # See default PAM configuration files provided for login, su, etc.
 # This is a temporary situation: setting these variables will soon move to `/etc/default/useradd` and the variables will then be no more supported
 MAIL_DIR        /var/mail
@@ -25,7 +25,7 @@ MAIL_DIR        /var/mail
 FAILLOG_ENAB    yes
 
 # Enable display of unknown usernames when login failures are recorded.
-# 
+#
 # *WARNING*: Unknown usernames may become world readable. See #290803 and #298773 for details about how this could become a security concern
 LOG_UNKFAIL_ENAB  no
 
@@ -56,9 +56,8 @@ HUSHLOGIN_FILE  .hushlogin
 
 # *REQUIRED*: The default PATH settings, for superuser and normal users. (they are minimal, add the rest in the shell startup files)
 ENV_SUPATH  PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV_PATH  PATH=/usr/local/bin:/usr/bin:/bin<% if not @additional_user_paths.empty? %>:<%= @additional_user_paths %><% end %>
+ENV_PATH  PATH=/usr/local/bin:/usr/bin:/bin<% if not scope['os_hardening::extra_user_paths'].empty? %>:<%= scope['os_hardening::additional_user_paths'] %><% end %>
 
-# Terminal permissions
 # --------------------
 
 # Login tty will be assigned this group ownership.
@@ -84,7 +83,7 @@ KILLCHAR  025
 # Prefix these values with `0` to get octal, `0x` to get hexadecimal.
 # `022` is the "historical" value in Debian for UMASK
 # `027`, or even `077`, could be considered better for privacy.
-UMASK   <%= @umask %>
+UMASK <%= scope['os_hardening::umask'] %>
 
 # Enable setting of the umask group bits to be the same as owner bits (examples: `022` -> `002`, `077` -> `007`) for non-root users, if the uid is the same as gid, and username is the same as the primary group name.
 # If set to yes, userdel will remove the user's group if it contains no more members, and useradd will create by default a group with the name of the user.
@@ -95,10 +94,10 @@ USERGROUPS_ENAB yes
 # -----------------------
 
 # Maximum number of days a password may be used.
-PASS_MAX_DAYS <%= @password_max_age.to_s %>
+PASS_MAX_DAYS <%= scope['os_hardening::password_max_age'] %>
 
 # Minimum number of days allowed between password changes.
-PASS_MIN_DAYS <%= @password_min_age.to_s %>
+PASS_MIN_DAYS <%= scope['os_hardening::password_min_age'] %>
 
 # Number of days warning given before a password expires.
 PASS_WARN_AGE 7
@@ -107,30 +106,30 @@ PASS_WARN_AGE 7
 UID_MIN      1000
 UID_MAX     60000
 # System accounts
-#SYS_UID_MIN      100
-#SYS_UID_MAX      999
+SYS_UID_MIN <%= scope['os_hardening::sys_uid_min'] %>
+SYS_UID_MAX <%= scope['os_hardening::sys_uid_max'] %>
 
 # Min/max values for automatic gid selection in groupadd
 GID_MIN      1000
 GID_MAX     60000
 # System accounts
-#SYS_GID_MIN      100
-#SYS_GID_MAX      999
+SYS_GID_MIN <%= scope['os_hardening::sys_gid_min'] %>
+SYS_GID_MAX <%= scope['os_hardening::sys_gid_max'] %>
 
 # Max number of login retries if password is bad. This will most likely be overriden by PAM, since the default pam_unix module has it's own built in of 3 retries. However, this is a safe fallback in case you are using an authentication module that does not enforce PAM_MAXTRIES.
-LOGIN_RETRIES   <%= @login_retries.to_s %>
+LOGIN_RETRIES <%= scope['os_hardening::login_retries'] %>
 
 # Max time in seconds for login
-LOGIN_TIMEOUT   <%= @login_timeout.to_s %>
+LOGIN_TIMEOUT <%= scope['os_hardening::login_timeout'] %>
 
 # Which fields may be changed by regular users using chfn - use any combination of letters "frwh" (full name, room number, work phone, home phone).  If not defined, no changes are allowed.
 # For backward compatibility, "yes" = "rwh" and "no" = "frwh".
-<% if not @chfn_restrict.empty? %>
-CHFN_RESTRICT   <%= @chfn_restrict %>
+<% if scope['os_hardening::chfn_restrict'] != 'UNSET' %>
+CHFN_RESTRICT <%= scope['os_hardening::chfn_restrict'] %>
 <% end %>
 
 # Should login be allowed if we can't cd to the home directory?
-DEFAULT_HOME  <%= @allow_login_without_home ? "yes" : "no" %>
+DEFAULT_HOME <%= scope['os_hardening::allow_login_without_home'] ? "yes" : "no" %>
 
 # If defined, this command is run when removing a user.
 # It should remove any at/cron/print jobs etc. owned by
@@ -207,4 +206,3 @@ ENCRYPT_METHOD SHA512
 # This variable is deprecated. You should use ENCRYPT_METHOD.
 #
 #MD5_CRYPT_ENAB no
-


### PR DESCRIPTION
This sets the SYS_UID_MIN/MAX SYS_GID_MIN/MAX values in the template
file to match those asserted by the tests-os-hardening inspec tests.

This is also the default behavour of the ansible playbook and chef
cookbook.

Adds puppet-rspec tests for the login.defs