### PR TITLE
Lynis Suggestion for Debian

### DIFF
--- a/files/dev-sec.conf
+++ b/files/dev-sec.conf
@@ -1,0 +1,8 @@
+install cramfs /bin/true
+install freevxfs /bin/true
+install jffs2 /bin/true
+install hfs /bin/true
+install hfsplus /bin/true
+install squashfs /bin/true
+install udf /bin/true
+install vfat /bin/true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,9 +52,9 @@ class os_hardening(
   $enable_sysrq             = false,
   $enable_core_dump         = false,
   $enable_stack_protection  = true,
-  $sysstat_enabled	    = true,
+  $sysstat_enabled          = true,
   $legal_warning            = true,
-  $company_name             = "Example"
+  $company_name             = 'Example'
 ) {
   # Validate
   # --------
@@ -126,8 +126,8 @@ class os_hardening(
   }
 
   class {'os_hardening::issue':
-    legal_warning  => $legal_warning,
-    company_name   => $company_name,
+    legal_warning => $legal_warning,
+    company_name  => $company_name,
   }
 
   class {'os_hardening::lynis_packages':}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,6 +131,7 @@ class os_hardening(
   }
 
   class {'os_hardening::lynis_packages':}
+  class {'os_hardening::modprobe':}
 
   if $configure_sysctl {
     class {'os_hardening::sysctl':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,8 @@ class os_hardening(
     sysstat_enabled          => $sysstat_enabled,
   }
 
+  class {'os_hardening::lynis_packages':}
+
   if $configure_sysctl {
     class {'os_hardening::sysctl':
       enable_module_loading   => $enable_module_loading,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,9 @@ class os_hardening(
   $enable_sysrq             = false,
   $enable_core_dump         = false,
   $enable_stack_protection  = true,
+  $sysstat_enabled	    = true,
+  $legal_warning            = true,
+  $company_name             = "Example"
 ) {
   # Validate
   # --------
@@ -120,6 +123,11 @@ class os_hardening(
 
   class {'os_hardening::sysstat':
     sysstat_enabled          => $sysstat_enabled,
+  }
+
+  class {'os_hardening::issue':
+    legal_warning  => $legal_warning,
+    company_name   => $company_name,
   }
 
   class {'os_hardening::lynis_packages':}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,10 @@ class os_hardening(
     dry_run_on_unknown  => $dry_run_on_unknown,
   }
 
+  class {'os_hardening::rc':
+    umask                    => $umask,
+  }
+
   if $configure_sysctl {
     class {'os_hardening::sysctl':
       enable_module_loading   => $enable_module_loading,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,6 +118,10 @@ class os_hardening(
     umask                    => $umask,
   }
 
+  class {'os_hardening::sysstat':
+    sysstat_enabled          => $sysstat_enabled,
+  }
+
   if $configure_sysctl {
     class {'os_hardening::sysctl':
       enable_module_loading   => $enable_module_loading,

--- a/manifests/issue.pp
+++ b/manifests/issue.pp
@@ -11,24 +11,24 @@
 #
 class os_hardening::issue (
   $legal_warning = false,
-  $company_name = "Example"
+  $company_name = 'Example'
 ){
   if $legal_warning == true {
     $str = "${lsbdistdescription}
 
 This computer system (including all hardware , software and peripheral equipment) is the property of the ${company_name} organization.
-${company_name} reserves the right to monitor the use of the computer system to ensure its compliance with ${company_name} security protocols. 
-Any additional monitoring, such as monitoring of performance or working hours, shall only take place if permitted in accordance with local laws, 
-regulations and/or policies. Any unauthorized access, use or modification of the computer system may be sanctioned in accordance with local laws, regulations and/or policies. 
+${company_name} reserves the right to monitor the use of the computer system to ensure its compliance with ${company_name} security 
+protocols. Any additional monitoring, such as monitoring of performance or working hours, shall only take place if permitted in accordance 
+with local laws, regulations and/or policies. Any unauthorized access, use or modification of the computer system may be sanctioned in 
+accordance with local laws, regulations and/or policies. 
 
 "
-	
     file { ['/etc/issue','/etc/issue.net']:
-        ensure => present,
+        ensure  => present,
         content => $str,
-        owner  => root,
-        group  => root,
-        mode   => '0644',
+        owner   => root,
+        group   => root,
+        mode    => '0644',
     }
   }
 }

--- a/manifests/issue.pp
+++ b/manifests/issue.pp
@@ -1,0 +1,34 @@
+# === Copyright
+#
+# Copyright 2014, Deutsche Telekom AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# == Class: os_hardening::issue
+#
+# Configures the content of /etc/issue and /etc/issue.net
+#
+class os_hardening::issue (
+  $legal_warning = false,
+  $company_name = "Example"
+){
+  if $legal_warning == true {
+    $str = "${lsbdistdescription}
+
+This computer system (including all hardware , software and peripheral equipment) is the property of the ${company_name} organization.
+${company_name} reserves the right to monitor the use of the computer system to ensure its compliance with ${company_name} security protocols. 
+Any additional monitoring, such as monitoring of performance or working hours, shall only take place if permitted in accordance with local laws, 
+regulations and/or policies. Any unauthorized access, use or modification of the computer system may be sanctioned in accordance with local laws, regulations and/or policies. 
+
+"
+	
+    file { ['/etc/issue','/etc/issue.net']:
+        ensure => present,
+        content => $str,
+        owner  => root,
+        group  => root,
+        mode   => '0644',
+    }
+  }
+}

--- a/manifests/issue.pp
+++ b/manifests/issue.pp
@@ -14,7 +14,7 @@ class os_hardening::issue (
   $company_name = 'Example'
 ){
   if $legal_warning == true {
-    $str = "${lsbdistdescription}
+    $str = "${::lsbdistdescription}
 
 This computer system (including all hardware , software and peripheral equipment) is the property of the ${company_name} organization.
 ${company_name} reserves the right to monitor the use of the computer system to ensure its compliance with ${company_name} security 

--- a/manifests/issue.pp
+++ b/manifests/issue.pp
@@ -1,6 +1,6 @@
 # === Copyright
 #
-# Copyright 2014, Deutsche Telekom AG
+# Copyright 2017, Vijay Kumar - bitvijays
 # Licensed under the Apache License, Version 2.0 (the "License");
 # http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/manifests/lynis_packages.pp
+++ b/manifests/lynis_packages.pp
@@ -7,29 +7,26 @@
 
 # == Class: os_hardening::lynis_packages
 #
-# Configures Multiple packages as suggested by Lynis: apt-listbugs, apt-listchanges, checkrestart, needrestart, debsecan, debsums, fail2ban,  libapache2-mod-evasive, libapache2-mod-qos, libapache2-mod-security2, arpwatch,
-# arpon, rkhunter, chkrootkit, libpam-tmpdir
-#
-#
-#
+# Configures Multiple packages as suggested by Lynis: apt-listbugs, apt-listchanges, checkrestart, needrestart, debsecan, debsums, 
+# fail2ban,  libapache2-mod-evasive, libapache2-mod-qos, libapache2-mod-security2, arpwatch, arpon, rkhunter, chkrootkit, libpam-tmpdir
 #
 class os_hardening::lynis_packages{
-  package { 'apt-listbugs'		: ensure => 'installed' }
-  package { 'apt-listchanges'		: ensure => 'installed' }
-  package { 'debian-goodies'		: ensure => 'installed' }
-  package { 'needrestart'		: ensure => 'installed' }
-  package { 'debsecan'			: ensure => 'installed' }
-  package { 'debsums'			: ensure => 'installed' }
-  package { 'fail2ban'			: ensure => 'installed' }
-  package { 'libapache2-mod-evasive'	: ensure => 'installed' }
-  package { 'libapache2-mod-qos'	: ensure => 'installed' }
-  package { 'libapache2-mod-security2'	: ensure => 'installed' }
-  package { 'arpwatch'			: ensure => 'installed' }
-  package { 'arpon'			: ensure => 'installed' }
-  package { 'rkhunter'			: ensure => 'installed' }
-  package { 'chkrootkit'		: ensure => 'installed' }
-  package { 'libpam-tmpdir'		: ensure => 'installed' }
-  package { 'acct'			: ensure => 'installed' }
-  package { 'sysstat'			: ensure => 'installed' }
+  package { 'apt-listbugs'              : ensure => 'installed' }
+  package { 'apt-listchanges'           : ensure => 'installed' }
+  package { 'debian-goodies'            : ensure => 'installed' }
+  package { 'needrestart'               : ensure => 'installed' }
+  package { 'debsecan'                  : ensure => 'installed' }
+  package { 'debsums'                   : ensure => 'installed' }
+  package { 'fail2ban'                  : ensure => 'installed' }
+  package { 'libapache2-mod-evasive'    : ensure => 'installed' }
+  package { 'libapache2-mod-qos'        : ensure => 'installed' }
+  package { 'libapache2-mod-security2'  : ensure => 'installed' }
+  package { 'arpwatch'                  : ensure => 'installed' }
+  package { 'arpon'                     : ensure => 'installed' }
+  package { 'rkhunter'                  : ensure => 'installed' }
+  package { 'chkrootkit'                : ensure => 'installed' }
+  package { 'libpam-tmpdir'             : ensure => 'installed' }
+  package { 'acct'                      : ensure => 'installed' }
+  package { 'sysstat'                   : ensure => 'installed' }
 }
 

--- a/manifests/lynis_packages.pp
+++ b/manifests/lynis_packages.pp
@@ -1,0 +1,35 @@
+# === Copyright
+#
+# Copyright 2017, bitvijays
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# == Class: os_hardening::lynis_packages
+#
+# Configures Multiple packages as suggested by Lynis: apt-listbugs, apt-listchanges, checkrestart, needrestart, debsecan, debsums, fail2ban,  libapache2-mod-evasive, libapache2-mod-qos, libapache2-mod-security2, arpwatch,
+# arpon, rkhunter, chkrootkit, libpam-tmpdir
+#
+#
+#
+#
+class os_hardening::lynis_packages{
+  package { 'apt-listbugs'		: ensure => 'installed' }
+  package { 'apt-listchanges'		: ensure => 'installed' }
+  package { 'debian-goodies'		: ensure => 'installed' }
+  package { 'needrestart'		: ensure => 'installed' }
+  package { 'debsecan'			: ensure => 'installed' }
+  package { 'debsums'			: ensure => 'installed' }
+  package { 'fail2ban'			: ensure => 'installed' }
+  package { 'libapache2-mod-evasive'	: ensure => 'installed' }
+  package { 'libapache2-mod-qos'	: ensure => 'installed' }
+  package { 'libapache2-mod-security2'	: ensure => 'installed' }
+  package { 'arpwatch'			: ensure => 'installed' }
+  package { 'arpon'			: ensure => 'installed' }
+  package { 'rkhunter'			: ensure => 'installed' }
+  package { 'chkrootkit'		: ensure => 'installed' }
+  package { 'libpam-tmpdir'		: ensure => 'installed' }
+  package { 'acct'			: ensure => 'installed' }
+  package { 'sysstat'			: ensure => 'installed' }
+}
+

--- a/manifests/modprobe.pp
+++ b/manifests/modprobe.pp
@@ -1,0 +1,21 @@
+# === Copyright
+#
+# Copyright 2017, Vijay Kumar - bitvijays
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# == Class: os_hardening::modprobe
+#
+# Configures the dev-sec.conf. Sets:
+# CIS: Disable unused filesystems - Ensure mounting of cramfs, freevxfs, jffs2, hfs, hfsplus, squashfs, udf, FAT#
+#
+class os_hardening::modprobe{
+    file { '/etc/modeprobe.d/dev-sec.conf':
+        ensure => present,
+        source => 'puppet:///modules/os_hardening/dev-sec.conf',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0640',
+    }
+  }

--- a/manifests/rc.pp
+++ b/manifests/rc.pp
@@ -1,0 +1,24 @@
+# === Copyright
+#
+# Copyright 2014, Deutsche Telekom AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# == Class: os_hardening::rc
+#
+# Configures /etc/init.d/rc
+#
+class os_hardening::rc (
+  $umask = '027',
+){
+  # set the file
+  file {
+    '/etc/init.d/rc':
+      ensure  => present,
+      content => template( 'os_hardening/rc.erb' ),
+      owner   => root,
+      group   => root,
+      mode    => '0755',
+  }
+}

--- a/manifests/rc.pp
+++ b/manifests/rc.pp
@@ -1,6 +1,6 @@
 # === Copyright
 #
-# Copyright 2014, Deutsche Telekom AG
+# Copyright 2017, Vijay Kumar - bitvijays
 # Licensed under the Apache License, Version 2.0 (the "License");
 # http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -156,8 +156,8 @@ class os_hardening::sysctl (
   #Lynis suggested values implemented
   sysctl { 'net.ipv4.conf.default.log_martians' : value => '1' }
   sysctl { 'net.ipv4.conf.all.log_martians'     : value => '1' }
-  sysctl { 'kernel.kptr_restrict' 		: value => '2' }
-  sysctl { 'kernel.core_uses_pid'		: value => '1' }
+  sysctl { 'kernel.kptr_restrict'               : value => '2' }
+  sysctl { 'kernel.core_uses_pid'               : value => '1' }
 
 
   # System

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -153,6 +153,11 @@ class os_hardening::sysctl (
 
   # log martian packets (risky, may cause DoS)
   #net.ipv4.conf.all.log_martians = 1
+  #Lynis suggested values implemented
+  sysctl { 'net.ipv4.conf.default.log_martians' : value => '1' }
+  sysctl { 'net.ipv4.conf.all.log_martians'     : value => '1' }
+  sysctl { 'kernel.kptr_restrict' 		: value => '2' }
+  sysctl { 'kernel.core_uses_pid'		: value => '1' }
 
 
   # System

--- a/manifests/sysstat.pp
+++ b/manifests/sysstat.pp
@@ -1,0 +1,24 @@
+# === Copyright
+#
+# Copyright 2014, Deutsche Telekom AG
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# == Class: os_hardening::sysstat
+#
+# Configures /etc/default/sysstat
+#
+class os_hardening::sysstat (
+  $sysstat_enabled = 'true',
+){
+  # set the file
+  file {
+    '/etc/default/sysstat':
+      ensure  => present,
+      content => template( 'os_hardening/sysstat.erb' ),
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+  }
+}

--- a/manifests/sysstat.pp
+++ b/manifests/sysstat.pp
@@ -10,7 +10,7 @@
 # Configures /etc/default/sysstat
 #
 class os_hardening::sysstat (
-  $sysstat_enabled = 'true',
+  $sysstat_enabled = true,
 ){
   # set the file
   file {

--- a/manifests/sysstat.pp
+++ b/manifests/sysstat.pp
@@ -1,6 +1,6 @@
 # === Copyright
 #
-# Copyright 2014, Deutsche Telekom AG
+# Copyright 2017, Vijay Kumar - bitvijays
 # Licensed under the Apache License, Version 2.0 (the "License");
 # http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/templates/rc.erb
+++ b/templates/rc.erb
@@ -1,0 +1,263 @@
+#! /bin/sh
+#
+# rc
+#
+# Starts/stops services on runlevel changes.
+#
+# Optimization: A start script is not run when the service was already
+# configured to run in the previous runlevel.  A stop script is not run
+# when the the service was already configured not to run in the previous
+# runlevel.
+#
+# Authors:
+# 	Miquel van Smoorenburg <miquels@cistron.nl>
+# 	Bruce Perens <Bruce@Pixar.com>
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+export PATH
+
+# Un-comment the following for interactive debugging. Do not un-comment
+# this for debugging a real boot process as no scripts will be executed.
+# debug=echo
+
+# Make sure the name survive changing the argument list
+scriptname="$0"
+
+umask <%= @umask %>
+
+on_exit() {
+	echo "error: '$scriptname' exited outside the expected code flow."
+}
+trap on_exit EXIT # Enable emergency handler
+
+# Ignore CTRL-C only in this shell, so we can interrupt subprocesses.
+trap ":" INT QUIT TSTP
+
+# Set onlcr to avoid staircase effect.
+stty onlcr 0>&1
+
+# Now find out what the current and what the previous runlevel are.
+
+runlevel=$RUNLEVEL
+# Get first argument. Set new runlevel to this argument.
+[ "$1" != "" ] && runlevel=$1
+if [ "$runlevel" = "" ]
+then
+	echo "Usage: $scriptname <runlevel>" >&2
+	exit 1
+fi
+previous=$PREVLEVEL
+[ "$previous" = "" ] && previous=N
+
+export runlevel previous
+
+if [ -f /etc/default/rcS ] ; then
+	. /etc/default/rcS
+fi
+export VERBOSE
+
+if [ -f /lib/lsb/init-functions ] ; then
+	. /lib/lsb/init-functions
+else
+	log_action_msg() { echo $@; }
+	log_failure_msg() { echo $@; }
+	log_warning_msg() { echo $@; }
+fi
+
+#
+# Check if we are able to use make like booting.  It require the
+# insserv package to be enabled. Boot concurrency also requires
+# startpar to be installed.
+#
+CONCURRENCY=makefile
+test -s /etc/init.d/.depend.boot  || CONCURRENCY="none"
+test -s /etc/init.d/.depend.start || CONCURRENCY="none"
+test -s /etc/init.d/.depend.stop  || CONCURRENCY="none"
+if test -e /etc/init.d/.legacy-bootordering ; then
+	CONCURRENCY="none"
+fi
+if ! test -e /proc/stat; then
+	# startpar requires /proc/stat
+	if [ "$(uname)" = "GNU/kFreeBSD" ] ; then
+		mount -t linprocfs linprocfs /proc
+	elif [ "$(uname)" = "GNU" ] ; then
+		mount -t proc none /proc
+	fi
+fi
+if [ -x /lib/startpar/startpar ] ; then
+    STARTPAR=/lib/startpar/startpar
+else
+    STARTPAR=startpar
+fi
+$STARTPAR -v > /dev/null 2>&1 || CONCURRENCY="none"
+
+#
+# Start script or program.
+#
+case "$CONCURRENCY" in
+	makefile|startpar|shell) # startpar and shell are obsolete
+		CONCURRENCY=makefile
+		log_action_msg "Using makefile-style concurrent boot in runlevel $runlevel"
+		startup() {
+			eval "$($STARTPAR -p 4 -t 20 -T 3 -M $1 -P $previous -R $runlevel)"
+
+			if [ -n "$failed_service" ]
+			then
+				log_failure_msg "startpar: service(s) returned failure: $failed_service"
+			fi
+
+			if [ -n "$skipped_service_not_installed" ]
+			then
+				log_warning_msg "startpar: service(s) skipped, program is not installed: $skipped_service_not_installed"
+			fi
+
+			if [ -n "$skipped_service_not_configured" ]
+			then
+				log_warning_msg "startpar: service(s) skipped, program is not configured: $skipped_service_not_configured"
+			fi
+
+			unset failed_service skipped_service_not_installed skipped_service_not_configured
+		}
+		;;
+	none|*)
+		startup() {
+			action=$1
+			shift
+			scripts="$@"
+			for script in $scripts ; do
+				$debug "$script" $action
+			done
+		}
+		;;
+esac
+
+# Is there an rc directory for this new runlevel?
+if [ -d /etc/rc$runlevel.d ]
+then
+	case "$runlevel" in
+		0|6)
+			ACTION=stop
+			;;
+		S)
+			ACTION=start
+			;;
+		*)
+			ACTION=start
+			;;
+	esac
+
+	# First, run the KILL scripts.
+	if [ makefile = "$CONCURRENCY" ]
+	then
+		if [ "$ACTION" = "start" ] && [ "$previous" != N ]
+		then
+			startup stop
+		fi
+	elif [ "$previous" != N ]
+	then
+		# Run all scripts with the same level in parallel
+		CURLEVEL=""
+		for s in /etc/rc$runlevel.d/K*
+		do
+			# Extract order value from symlink
+			level=${s#/etc/rc$runlevel.d/K}
+			level=${level%%[a-zA-Z]*}
+			if [ "$level" = "$CURLEVEL" ]
+			then
+				continue
+			fi
+			CURLEVEL=$level
+			SCRIPTS=""
+			for i in /etc/rc$runlevel.d/K$level*
+			do
+				# Check if the script is there.
+				[ ! -f $i ] && continue
+
+				#
+				# Find stop script in previous runlevel but
+				# no start script there.
+				#
+				suffix=${i#/etc/rc$runlevel.d/K[0-9][0-9]}
+				previous_stop=/etc/rc$previous.d/K[0-9][0-9]$suffix
+				previous_start=/etc/rc$previous.d/S[0-9][0-9]$suffix
+				#
+				# If there is a stop script in the previous level
+				# and _no_ start script there, we don't
+				# have to re-stop the service.
+				#
+				[ -f $previous_stop ] && [ ! -f $previous_start ] && continue
+
+				# Stop the service.
+				SCRIPTS="$SCRIPTS $i"
+			done
+			startup stop $SCRIPTS
+		done
+	fi
+
+	if [ makefile = "$CONCURRENCY" ]
+	then
+		if [ S = "$runlevel" ]
+		then
+			startup boot
+		else
+			startup $ACTION
+		fi
+	else
+		# Now run the START scripts for this runlevel.
+		# Run all scripts with the same level in parallel
+		CURLEVEL=""
+		for s in /etc/rc$runlevel.d/S*
+		do
+			# Extract order value from symlink
+			level=${s#/etc/rc$runlevel.d/S}
+			level=${level%%[a-zA-Z]*}
+			if [ "$level" = "$CURLEVEL" ]
+			then
+				continue
+			fi
+			CURLEVEL=$level
+			SCRIPTS=""
+			for i in /etc/rc$runlevel.d/S$level*
+			do
+				[ ! -f $i ] && continue
+
+				suffix=${i#/etc/rc$runlevel.d/S[0-9][0-9]}
+				if [ "$previous" != N ]
+				then
+					#
+					# Find start script in previous runlevel and
+					# stop script in this runlevel.
+					#
+					stop=/etc/rc$runlevel.d/K[0-9][0-9]$suffix
+					previous_start=/etc/rc$previous.d/S[0-9][0-9]$suffix
+					#
+					# If there is a start script in the previous level
+					# and _no_ stop script in this level, we don't
+					# have to re-start the service.
+					#
+					if [ start = "$ACTION" ] ; then
+						[ -f $previous_start ] && [ ! -f $stop ] && continue
+					else
+						# Workaround for the special
+						# handling of runlevels 0 and 6.
+						previous_stop=/etc/rc$previous.d/K[0-9][0-9]$suffix
+						#
+						# If there is a stop script in the previous level
+						# and _no_ start script there, we don't
+						# have to re-stop the service.
+						#
+						[ -f $previous_stop ] && [ ! -f $previous_start ] && continue
+					fi
+
+				fi
+				SCRIPTS="$SCRIPTS $i"
+			done
+			startup $ACTION $SCRIPTS
+		done
+	fi
+fi
+
+trap - EXIT # Disable emergency handler
+
+exit 0
+

--- a/templates/sysstat.erb
+++ b/templates/sysstat.erb
@@ -1,0 +1,10 @@
+#
+# Default settings for /etc/init.d/sysstat, /etc/cron.d/sysstat
+# and /etc/cron.daily/sysstat files
+#
+
+# Should sadc collect system activity informations? Valid values
+# are "true" and "false". Please do not put other values, they
+# will be overwritten by debconf!
+ENABLED="<%= @sysstat_enabled %>"
+


### PR DESCRIPTION
Dear Puppet-os-hardening team,

Thank you for creating awesome puppet os hardening modules. This is pull request for more os-hardening as suggested by Lynis Auditing tool. Below are the changes:

1. Lynis: Setting umask 027 in /etc/init.d/rc
- Created a new rc.pp in manifest folder and rc.erb in template folder
- Added class os_hardening::rc in the init.pp

2. Lynis: Install suggested packages by lynis: such as apt-listbugs, apt-listchanges, checkrestart, needrestart, debsecan, debsums, fail2ban,  libapache2-mod-evasive, libapache2-mod-qos, libapache2-mod-security2, arpwatch, arpon, rkhunter, chkrootkit, libpam-tmpdir.

- Added a new lynis_packages.pp in the manifest folder and included in init.pp

3. Lynis: Setting systat enabled in /etc/default/sysstat

- Added a new sysstat.pp in the manifest folder and sysstat.erb in the templates. 
- Included in init.pp

Please let me know if any this could be merged. This would help it to improve the Lynis score further.

Yours Sincerely,
Vijay