### PR TITLE
Fix the CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 ---
 AllCops:
+  DisplayCopNames: true
   Exclude:
   - vendor/**/*
   - test/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,9 @@
 sudo: false
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
   - 2.1.0
 language: ruby
 bundler_args: --without development integration openstack
 env:
   - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 3.7.5"
-  - PUPPET_VERSION="~> 3.6.2"
-  - PUPPET_VERSION="~> 2.7.0"
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 4.0.0"
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 4.0.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 4.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 source 'https://rubygems.org'
 
 puppetversion = ENV['PUPPET_VERSION']
@@ -10,15 +8,13 @@ else
 end
 
 group :test do
-  gem 'rake'
-  # bugfix for ruby 1.8, puppet+rspec interplay
-  # https://github.com/rspec/rspec-core/issues/1864
-  gem 'rspec', '~> 3.1.0', :require => false if RUBY_VERSION.start_with? '1.8'
-  gem 'rspec-puppet'
+  gem 'puppet-lint'
   # avoid NoMethodError: private method `clone' called for #<RuboCop::Cop::CopStore:0x00000104e286c8>
   gem 'puppetlabs_spec_helper', :git => 'https://github.com/ehaselwanter/puppetlabs_spec_helper'
-  gem 'puppet-lint'
-  gem 'rubocop', '~> 0.31' if RUBY_VERSION > '1.9.2'
+  gem 'rake'
+  gem 'rspec'
+  gem 'rspec-puppet'
+  gem 'rubocop'
 end
 
 group :development do
@@ -26,13 +22,9 @@ group :development do
 end
 
 group :integration do
-  gem 'test-kitchen'
-  gem 'kitchen-vagrant'
   gem 'kitchen-puppet'
-  gem 'librarian-puppet'
   gem 'kitchen-sharedtests', '~> 0.2.0'
-end
-
-group :openstack do
-  gem 'kitchen-openstack'
+  gem 'kitchen-vagrant'
+  gem 'librarian-puppet'
+  gem 'test-kitchen'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ puppetversion = ENV['PUPPET_VERSION']
 if puppetversion
   gem 'puppet', puppetversion, :require => false
 else
-  gem 'puppet', :require => false
+  gem 'puppet', :require => false # rubocop:disable Bundler/DuplicatedGem
 end
 
 group :test do

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Guardfile
 
 guard 'rake', :task => 'lint' do

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 #!/usr/bin/env rake
-# encoding: utf-8
+
+# rubocop:disable Style/SymbolArray
 
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppetlabs_spec_helper/rake_tasks'

--- a/Thorfile
+++ b/Thorfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'bundler'
 require 'bundler/setup'
 require 'kitchen_sharedtests'

--- a/lib/facter/retrieve_system_users.rb
+++ b/lib/facter/retrieve_system_users.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # Try to read UID_MIN from /etc/login.defs to caluclate SYS_UID_MAX
 # if that fails set some predefined values based on os_family fact.
 logindefs = '/etc/login.defs'

--- a/lib/puppet/parser/functions/combine_sugid_lists.rb
+++ b/lib/puppet/parser/functions/combine_sugid_lists.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright 2014, Deutsche Telekom AG
 #

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright 2014, Deutsche Telekom AG
 #
@@ -17,7 +16,7 @@
 
 require 'spec_helper'
 
-describe 'os_hardening::sysctl' do
+describe 'os_hardening::sysctl' do # rubocop:disable Metrics/BlockLength
 
   it { should contain_class('os_hardening::sysctl') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 #
 # Copyright 2014, Deutsche Telekom AG
 #


### PR DESCRIPTION
 - dropping very old puppet versions
 - making rubocop happy

The CI will be probably still red because of puppetlint warnings