### PR TITLE
CentOS7 issue - revert "Remove link following in minimize_access file resource"

### DIFF
--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -29,6 +29,7 @@ class os_hardening::minimize_access (
   # this prevents changing any system-wide command from normal users
   file { $folders:
     ensure  => 'directory',
+    links   => 'follow',
     mode    => 'go-w',
     recurse => true,
   }


### PR DESCRIPTION
On my (default installation) CentOS 7 systems this commit purges /bin and /sbin, as both directories are symbolic links:
- /bin -> usr/bin
- /sbin -> usr/sbin

Therefore `link -> 'follow'` must be included here!
