### PR TITLE
Baseline os-05b: set SYS_[GU]ID_[MIN|MAX] in /etc/login.defs

### DIFF
--- a/templates/login.defs.erb
+++ b/templates/login.defs.erb
@@ -107,15 +107,15 @@ PASS_WARN_AGE 7
 UID_MIN      1000
 UID_MAX     60000
 # System accounts
-#SYS_UID_MIN      100
-#SYS_UID_MAX      999
+SYS_UID_MIN   100
+SYS_UID_MAX   999
 
 # Min/max values for automatic gid selection in groupadd
 GID_MIN      1000
 GID_MAX     60000
 # System accounts
-#SYS_GID_MIN      100
-#SYS_GID_MAX      999
+SYS_GID_MIN   100
+SYS_GID_MAX   999
 
 # Max number of login retries if password is bad. This will most likely be overriden by PAM, since the default pam_unix module has it's own built in of 3 retries. However, this is a safe fallback in case you are using an authentication module that does not enforce PAM_MAXTRIES.
 LOGIN_RETRIES   <%= @login_retries.to_s %>


### PR DESCRIPTION
set SYS_[GU]ID_MIN and SYS_[GU]ID_MAX in /etc/login.defs

_IMHO this should be a sane default setting for every distribution (as the Baseline restricts this only to RedHat) ..._