### PR TITLE
Fix for Linux Baseline os-02

### DIFF
--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -33,12 +33,24 @@ class os_hardening::minimize_access (
     mode    => 'go-w',
     recurse => true,
   }
+
   # shadow must only be accessible to user root
+  case $::operatingsystem {
+    'debian', 'ubuntu', 'opensuse', 'sles': {
+      $shadowgroup = 'shadow'
+      $shadowmode  = '0640'
+    }
+    default: {
+      $shadowgroup = 'root'
+      $shadowmode  = '0600'
+    }
+  }
+
   file { '/etc/shadow':
     ensure => file,
     owner  => 'root',
-    group  => 'root',
-    mode   => '0600',
+    group  => $shadowgroup,
+    mode   => $shadowmode,
   }
 
   # su must only be accessible to user and group root


### PR DESCRIPTION
- for SUSE and Ubuntu environments: group should be "shadow" and file mode "0640"
(for SUSE also corrected in Baseline, see https://github.com/dev-sec/linux-baseline/pull/70)