### PR TITLE
One single coredump parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,6 @@
 #
 class os_hardening (
   $system_environment       = 'default',
-  $allow_core_dumps         = false,
 
   $extra_user_paths         = [],
   $umask                    = '027',
@@ -80,7 +79,7 @@ class os_hardening (
   # Install
   # -------
   class { 'os_hardening::limits':
-    allow_core_dumps => $allow_core_dumps,
+    enable_core_dump => $enable_core_dump,
   }
   class { 'os_hardening::login_defs':
     extra_user_paths         => $extra_user_paths,
@@ -106,7 +105,7 @@ class os_hardening (
     pw_remember_last  => $pw_remember_last,
   }
   class { 'os_hardening::profile':
-    allow_core_dumps => $allow_core_dumps,
+    enable_core_dump => $enable_core_dump,
   }
   class { 'os_hardening::securetty':
     root_ttys => $root_ttys,

--- a/manifests/limits.pp
+++ b/manifests/limits.pp
@@ -12,10 +12,10 @@
 # * disable core dumps
 #
 class os_hardening::limits (
-  $allow_core_dumps = false,
+  $enable_core_dump = false,
 ) {
 
-  if $allow_core_dumps == false {
+  if $enable_core_dump == false {
     file { '/etc/security/limits.d/10.hardcore.conf':
       ensure => file,
       source => 'puppet:///modules/os_hardening/limits.conf',

--- a/manifests/profile.pp
+++ b/manifests/profile.pp
@@ -10,10 +10,10 @@
 # Configures profile.conf.
 #
 class os_hardening::profile (
-  $allow_core_dumps = false,
+  $enable_core_dump = false,
 ) {
 
-  if $allow_core_dumps == false {
+  if $enable_core_dump == false {
     file { '/etc/profile.d/pinerolo_profile.sh':
       ensure => file,
       source => 'puppet:///modules/os_hardening/profile.conf',


### PR DESCRIPTION
Integrate functionality of 'allow_core_dumps' in 'enable_core_dump'
(allow_core_dumps removed)
See discussion in #88 

Signed-off-by: Michael Geiger <michael.geiger@telekom.de>