### PR TITLE
Baseline sysctl-17: Enable logging of martian packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This Puppet module provides secure configuration of your base OS with hardening.
 * `enable_ipv6_forwarding   = false`
   true if this system requires packet forwarding in IPv6 (eg Router), false otherwise
 * `enable_ipv6 = false`
+* `enable_log_martians = true`
+  true to enable logging on suspicious / unroutable network packets, false otherwise **WARNING - this might generate huge log files!**
 * `arp_restricted = true`
   true if you want the behavior of announcing and replying to ARP to be restricted, false otherwise
 * `extra_user_paths = []`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class os_hardening (
   $enable_core_dump         = false,
   $enable_stack_protection  = true,
   $enable_rpfilter          = true,
+  $enable_log_martians      = true,
 ) {
 
   # Validate
@@ -132,6 +133,7 @@ class os_hardening (
       enable_core_dump        => $enable_core_dump,
       enable_stack_protection => $enable_stack_protection,
       enable_rpfilter         => $enable_rpfilter,
+      enable_log_martians     => $enable_log_martians,
     }
   }
 

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -23,6 +23,7 @@ class os_hardening::sysctl (
   $enable_core_dump        = false,
   $enable_stack_protection = true,
   $enable_rpfilter         = true,
+  $enable_log_martians     = true,
 ) {
 
   # set variables
@@ -161,7 +162,13 @@ class os_hardening::sysctl (
   sysctl { 'net.ipv4.conf.default.send_redirects': value => '0' }
 
   # log martian packets (risky, may cause DoS)
-  #net.ipv4.conf.all.log_martians = 1
+  if $enable_log_martians {
+    sysctl { 'net.ipv4.conf.all.log_martians': value => '1' }
+    sysctl { 'net.ipv4.conf.default.log_martians': value => '1' }
+  } else {
+    sysctl { 'net.ipv4.conf.all.log_martians': value => '0' }
+    sysctl { 'net.ipv4.conf.default.log_martians': value => '0' }
+  }
 
 
   # System


### PR DESCRIPTION
As this feature can produce large log files, it can be disabled via 'log_martians'

This PR implements sysctl-17 as discussed in https://github.com/dev-sec/linux-baseline/issues/48 and https://github.com/dev-sec/linux-baseline/pull/72 and should fix #66 

Signed-off-by: Michael Geiger <michael.geiger@telekom.de>