### PR TITLE
Avoid picking up users retrieved from SSSD or other domain services.

### DIFF
--- a/lib/facter/retrieve_system_users.rb
+++ b/lib/facter/retrieve_system_users.rb
@@ -22,8 +22,11 @@ end
 Facter.add(:retrieve_system_users) do
   sys_users = []
   Puppet::Type.type('user').instances.find_all do |user|
-    user_value = user.retrieve
-    sys_users.push(user.name) unless user_value[user.property(:uid)].to_i > su_maxid
+    # Avoid picking up non-local users
+    if user.name.index('@') == nil
+      user_value = user.retrieve
+      sys_users.push(user.name) unless user_value[user.property(:uid)].to_i > su_maxid
+    end
   end
   setcode do
     sys_users.join(',')

--- a/lib/facter/retrieve_system_users.rb
+++ b/lib/facter/retrieve_system_users.rb
@@ -23,7 +23,7 @@ Facter.add(:retrieve_system_users) do
   sys_users = []
   Puppet::Type.type('user').instances.find_all do |user|
     # Avoid picking up non-local users
-    if user.name.index('@') == nil
+    if user.name.index('@').nil?
       user_value = user.retrieve
       sys_users.push(user.name) unless user_value[user.property(:uid)].to_i > su_maxid
     end


### PR DESCRIPTION
When using this module with my SSSD configuration, the fact took a really long time to resolve. Excluding users with @ in their name fixed this, as those users can't be managed by Puppet anyway.