### PR TITLE
Fix permissions on /etc/gshadow, based on CIS DIL Benchmark 6.1.5.

### DIFF
--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -22,12 +22,15 @@ class os_hardening::minimize_access (
   case $::operatingsystem {
     redhat, fedora: {
       $nologin_path = '/sbin/nologin'
+      $shadow_path = ['/etc/shadow', '/etc/gshadow']
     }
     debian, ubuntu: {
       $nologin_path = '/usr/sbin/nologin'
+      $shadow_path = ['/etc/shadow', '/etc/gshadow']
     }
     default: {
       $nologin_path = '/sbin/nologin'
+      $shadow_path = '/etc/shadow'
     }
   }
   # from which folders to remove public access
@@ -50,7 +53,7 @@ class os_hardening::minimize_access (
   }
 
   # shadow must only be accessible to user root
-  file { '/etc/shadow':
+  file { $shadow_path:
     ensure => file,
     owner  => 'root',
     group  => $shadowgroup,


### PR DESCRIPTION
Fixes #132 