### PR TITLE
Deploy GRUB hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ This Puppet module provides secure configuration of your base OS with hardening.
   `true` if you want to remove SUID/SGID bits from any file, that is not explicitly configured in a `blacklist`. This will make every Puppet run search through the mounted filesystems looking for SUID/SGID bits that are not configured in the default and user blacklist. If it finds an SUID/SGID bit, it will be removed, unless this file is in your `whitelist`.
 * `dry_run_on_unknown = false`
   like `remove_from_unknown` above, only that SUID/SGID bits aren't removed. It will still search the filesystems to look for SUID/SGID bits but it will only print them in your log. This option is only ever recommended, when you first configure `remove_from_unknown` for SUID/SGID bits, so that you can see the files that are being changed and make adjustments to your `whitelist` and `blacklist`.
+* `enable_grub_hardening = false`
+  set to true to enable some grub hardening rules
+* `grub_user = 'root'`
+  the grub username that needs to be provided when changing config on the grub prompt
+* `grub_password_hash = false`
+  a password hash created with `grub-mkpasswd-pbkdf2` that is associated with the grub\_user
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This Puppet module provides secure configuration of your base OS with hardening.
   set to true to enable some grub hardening rules
 * `grub_user = 'root'`
   the grub username that needs to be provided when changing config on the grub prompt
-* `grub_password_hash = false`
+* `grub_password_hash = ''`
   a password hash created with `grub-mkpasswd-pbkdf2` that is associated with the grub\_user
 * `boot_without_password = true`
   setup Grub so it only requires a password when changing an entry, not when booting an existing entry

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ This Puppet module provides secure configuration of your base OS with hardening.
   the grub username that needs to be provided when changing config on the grub prompt
 * `grub_password_hash = false`
   a password hash created with `grub-mkpasswd-pbkdf2` that is associated with the grub\_user
+* `boot_without_password = true`
+  setup Grub so it only requires a password when changing an entry, not when booting an existing entry
 
 ## Usage
 

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -10,13 +10,23 @@
 # Hardens the grub config
 #
 class os_hardening::grub (
-  String  $user          = 'root',
-  String  $password_hash = false,
+  String  $user                  = 'root',
+  String  $password_hash         = false,
+  Boolean $boot_without_password = true,
 ) {
 
   file { '/etc/grub.d/01_hardening':
     content => template('os_hardening/grub_hardening.erb'),
     notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+  }
+
+  if $boot_without_password {
+    # This sets up Grub on Debian Stretch so you can still boot the system without a password
+    exec { 'Keep system bootable without credentials':
+      command => "/bin/sed -i -e 's/^CLASS=\"\\(.*\\)\"/CLASS=\"\\1 --unrestricted\"/' /etc/grub.d/10_linux;",
+      unless  => '/bin/grep -e "^CLASS=" /etc/grub.d/10_linux | /bin/grep -q "--unrestricted"',
+      notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+    }
   }
 
   exec { 'Grub configuration recreate for os_hardening::grub':

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -1,0 +1,34 @@
+# === Copyright
+#
+# Copyright 2018, Kumina B.V., Tim Stoop
+# Licensed under the Apache License, Version 2.0 (the "License");
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# == Class: os_hardening::grub
+#
+# Hardens the grub config
+#
+class os_hardening::grub (
+  String  $user          = 'root',
+  String  $password_hash = false,
+) {
+
+  file { '/etc/grub.d/01_hardening':
+    content => template('os_hardening/grub_hardening.erb'),
+    notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+  }
+
+  exec { 'Grub configuration recreate for os_hardening::grub':
+    command     => '/usr/sbin/update-grub',
+    refreshonly => true,
+  }
+
+  file { '/boot/grub/grub.cfg':
+    owner => 'root',
+    group => 'root',
+    mode  => '0600',
+  }
+
+}
+

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -24,7 +24,7 @@ class os_hardening::grub (
     # This sets up Grub on Debian Stretch so you can still boot the system without a password
     exec { 'Keep system bootable without credentials':
       command => "/bin/sed -i -e 's/^CLASS=\"\\(.*\\)\"/CLASS=\"\\1 --unrestricted\"/' /etc/grub.d/10_linux;",
-      unless  => '/bin/grep -e "^CLASS=" /etc/grub.d/10_linux | /bin/grep -q "--unrestricted"',
+      unless  => '/bin/grep -e "^CLASS=" /etc/grub.d/10_linux | /bin/grep -q -- "--unrestricted"',
       notify  => Exec['Grub configuration recreate for os_hardening::grub'],
     }
   }

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -21,7 +21,7 @@ class os_hardening::grub (
       $grub_cfg = '/boot/grub/grub.cfg'
       $grub_cmd = "/usr/sbin/grub-mkconfig"
     }
-    redhat, fedora: {
+    default: {
       $grub_cfg = '/boot/grub2/grub.cfg'
       $grub_cmd = "/usr/sbin/grub2-mkconfig"
     }

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -31,6 +31,7 @@ class os_hardening::grub (
     file { '/etc/grub.d/01_hardening':
       content => template('os_hardening/grub_hardening.erb'),
       notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+      mode    => '0755',
     }
 
     file { $grub_cfg:

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -10,34 +10,59 @@
 # Hardens the grub config
 #
 class os_hardening::grub (
+  Boolean $enable                = false,
   String  $user                  = 'root',
   String  $password_hash         = false,
   Boolean $boot_without_password = true,
 ) {
 
-  file { '/etc/grub.d/01_hardening':
-    content => template('os_hardening/grub_hardening.erb'),
-    notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+  case $::operatingsystem {
+    debian, ubuntu: {
+      $grub_cfg = '/boot/grub/grub.cfg'
+      $grub_cmd = "/usr/sbin/grub-mkconfig"
+    }
+    redhat, fedora: {
+      $grub_cfg = '/boot/grub2/grub.cfg'
+      $grub_cmd = "/usr/sbin/grub2-mkconfig"
+    }
   }
 
-  if $boot_without_password {
-    # This sets up Grub on Debian Stretch so you can still boot the system without a password
-    exec { 'Keep system bootable without credentials':
-      command => "/bin/sed -i -e 's/^CLASS=\"\\(.*\\)\"/CLASS=\"\\1 --unrestricted\"/' /etc/grub.d/10_linux;",
-      unless  => '/bin/grep -e "^CLASS=" /etc/grub.d/10_linux | /bin/grep -q -- "--unrestricted"',
+  if $enable {
+    file { '/etc/grub.d/01_hardening':
+      content => template('os_hardening/grub_hardening.erb'),
+      notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+    }
+
+    file { $grub_cfg:
+      owner => 'root',
+      group => 'root',
+      mode  => '0600',
+    }
+
+    if $boot_without_password {
+      # This sets up Grub on Debian Stretch so you can still boot the system without a password
+      exec { 'Keep system bootable without credentials':
+        command => "/bin/sed -i -e 's/^CLASS=\"\\(.*\\)\"/CLASS=\"\\1 --unrestricted\"/' /etc/grub.d/10_linux;",
+        unless  => '/bin/grep -e "^CLASS=" /etc/grub.d/10_linux | /bin/grep -q -- "--unrestricted"',
+        notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+      }
+    } else {
+      exec { 'Remove addition for keeping system bootable without credentials':
+        command => "/bin/sed -i -e 's/^CLASS=\"\\(.*\\) --unrestricted\\(.*\\)\"/CLASS=\"\\1\\2\"/' /etc/grub.d/10_linux;",
+        onlyif  => '/bin/grep -e "^CLASS=" /etc/grub.d/10_linux | /bin/grep -q -- "--unrestricted"',
+        notify  => Exec['Grub configuration recreate for os_hardening::grub'],
+      }
+    }
+  } else {
+    file { '/etc/grub.d/01_hardening':
+      ensure => absent,
       notify  => Exec['Grub configuration recreate for os_hardening::grub'],
     }
   }
 
   exec { 'Grub configuration recreate for os_hardening::grub':
-    command     => '/usr/sbin/update-grub',
+    command     => "${grub_cmd} -o ${grub_cfg}",
     refreshonly => true,
-  }
-
-  file { '/boot/grub/grub.cfg':
-    owner => 'root',
-    group => 'root',
-    mode  => '0600',
   }
 
 }

--- a/manifests/grub.pp
+++ b/manifests/grub.pp
@@ -12,7 +12,7 @@
 class os_hardening::grub (
   Boolean $enable                = false,
   String  $user                  = 'root',
-  String  $password_hash         = false,
+  String  $password_hash         = '',
   Boolean $boot_without_password = true,
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,10 @@ class os_hardening (
   Boolean           $enable_stack_protection  = true,
   Boolean           $enable_rpfilter          = true,
   Boolean           $enable_log_martians      = true,
+
+  Boolean           $enable_grub_hardening    = false,
+  String            $grub_user                = 'root',
+  String            $grub_password_hash       = false,
 ) {
 
   # Prepare
@@ -175,6 +179,13 @@ class os_hardening (
       enable_stack_protection => $enable_stack_protection,
       enable_rpfilter         => $enable_rpfilter,
       enable_log_martians     => $enable_log_martians,
+    }
+  }
+
+  if $enable_grub_hardening {
+    class { 'os_hardening::grub':
+      user          => $grub_user,
+      password_hash => $grub_password_hash,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ class os_hardening (
 
   Boolean           $enable_grub_hardening    = false,
   String            $grub_user                = 'root',
-  String            $grub_password_hash       = false,
+  String            $grub_password_hash       = '',
   Boolean           $boot_without_password    = true,
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -185,12 +185,11 @@ class os_hardening (
     }
   }
 
-  if $enable_grub_hardening {
-    class { 'os_hardening::grub':
-      user                  => $grub_user,
-      password_hash         => $grub_password_hash,
-      boot_without_password => $boot_without_password,
-    }
+  class { 'os_hardening::grub':
+    enable                => $enable_grub_hardening,
+    user                  => $grub_user,
+    password_hash         => $grub_password_hash,
+    boot_without_password => $boot_without_password,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class os_hardening (
   Boolean           $enable_grub_hardening    = false,
   String            $grub_user                = 'root',
   String            $grub_password_hash       = false,
+  Boolean           $boot_without_password    = true,
 ) {
 
   # Prepare
@@ -184,8 +185,9 @@ class os_hardening (
 
   if $enable_grub_hardening {
     class { 'os_hardening::grub':
-      user          => $grub_user,
-      password_hash => $grub_password_hash,
+      user                  => $grub_user,
+      password_hash         => $grub_password_hash,
+      boot_without_password => $boot_without_password,
     }
   }
 

--- a/templates/grub_hardening.erb
+++ b/templates/grub_hardening.erb
@@ -1,3 +1,4 @@
-set superusers="<%= @user %>"
-password_pbkdf2 <%= @user %> <%= @password_hash %>
+#!/bin/sh
+echo set superusers="<%= @user %>"
+echo password_pbkdf2 <%= @user %> <%= @password_hash %>
 

--- a/templates/grub_hardening.erb
+++ b/templates/grub_hardening.erb
@@ -1,3 +1,3 @@
-set superusers="<%= %user %>"
-password_pbkdf2 <%= %user %> <%= %password_hash %>
+set superusers="<%= @user %>"
+password_pbkdf2 <%= @user %> <%= @password_hash %>
 

--- a/templates/grub_hardening.erb
+++ b/templates/grub_hardening.erb
@@ -1,0 +1,3 @@
+set superusers="<%= %user %>"
+password_pbkdf2 <%= %user %> <%= %password_hash %>
+


### PR DESCRIPTION
This patch adds the option to harden GRUB. For this to work, it requires a password created with `grub-mkpasswd-pbkdf2` provided to it. Optionally, but enabled by default, this also modifies the Grub config to allow for unattended booting of these servers.

This was created to fulfil CIS DIL Benchmark 1.4.1 and 1.4.2. It was only tested on Debian Stretch, so I'd welcome someone to test on something else as well and let me know what I need to change to make it work on other OSes as well. Also, I'm not sure if I should wrap the exec that enables unattended booting in a case statement to select the operating system.