### PR TITLE
Add missing dependency

### DIFF
--- a/manifests/pam.pp
+++ b/manifests/pam.pp
@@ -74,6 +74,7 @@ class os_hardening::pam (
           owner   => 'root',
           group   => 'root',
           mode    => '0640',
+          require => Package['pam-passwdqc'],
           notify  => Exec['update-pam'],
         }
 


### PR DESCRIPTION
This commit adds a missing dependency between Package[pam-passwdqc] and
File[/usr/share/pam-configs/passwdqc].

Specifically, it fixes non-determinism. This is what I get if Puppet processes resources in the erroneous order.

```
Error: /Stage[main]/Os_hardening::Pam/File[/usr/share/pam-configs/passwdqc]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory @ dir_s_mkdir - /usr/share/pam-configs/passwdqc20190205-73-b7g10a.lock at /etc/puppet/code/modules/os_hardening/manifests/pam.pp:71
Notice: /Stage[main]/Os_hardening::Pam/Exec[update-pam]: Dependency File[/usr/share/pam-configs/passwdqc] has failures: true
Notice: /Stage[main]/Os_hardening::Pam/Exec[update-pam]: Dependency File[/usr/share/pam-configs/tally2] has failures: true
Warning: /Stage[main]/Os_hardening::Pam/Exec[update-pam]: Skipping because of failed dependencies
Notice: /Stage[main]/Os_hardening::Pam/Package[pam-passwdqc]/ensure: created
```