### PR TITLE
Disable sysctl configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,21 @@ Otherwise puppet will drop an error (duplicate resource)!
   setup Grub so it only requires a password when changing an entry, not when booting an existing entry
 * `system_umask = undef`
   if this variable is set setup the umask for all user in the system (e.g. '027')
-*`manage_home_permissions = false`
+* `manage_home_permissions = false`
   set to true to manage local users file and directory permissions (g-w,o-rwx) 
-*`ignore_home_users = []`
+* `ignore_home_users = []`
   array for users that is not to be restricted by manage_home_permissions
-*`manage_log_permissions = false`
+* `manage_log_permissions = false`
   set to true to manage log file permissions (g-wx,o-rwx)
-*`restrict_log_dir = ['/var/log/']`
+* `restrict_log_dir = ['/var/log/']`
   set main log dir
-*`ignore_restrict_log_dir = []`
+* `ignore_restrict_log_dir = []`
   array to exclude log dirs under the main log dir
-*`manage_cron_permissions = false`
+* `manage_cron_permissions = false`
   set to true to manage cron file permissions (og-rwx)
+* `enable_sysctl_config = true`
+  set to false to disable sysctl configuration
+
    
 
 ### Note about wanted/unwanted packages and disabled services

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,8 @@ class os_hardening (
   String            $grub_user                = 'root',
   String            $grub_password_hash       = '',
   Boolean           $boot_without_password    = true,
+  
+  Boolean           $enable_sysctl_config     = true,
 
   Optional[String]  $system_umask             = undef,
 ) {
@@ -98,7 +100,8 @@ class os_hardening (
   # sysctl configuration doesn't work in docker:
   $configure_sysctl = (
     $system_environment != 'lxc' and
-    $system_environment != 'docker'
+    $system_environment != 'docker' and 
+    $enable_sysctl_config
   )
 
   # Defaults for specific platforms

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,7 @@ class os_hardening (
   String            $grub_user                = 'root',
   String            $grub_password_hash       = '',
   Boolean           $boot_without_password    = true,
-  
+
   Boolean           $enable_sysctl_config     = true,
 
   Optional[String]  $system_umask             = undef,
@@ -100,7 +100,7 @@ class os_hardening (
   # sysctl configuration doesn't work in docker:
   $configure_sysctl = (
     $system_environment != 'lxc' and
-    $system_environment != 'docker' and 
+    $system_environment != 'docker' and
     $enable_sysctl_config
   )
 


### PR DESCRIPTION
Hello
Because I already use the sysctl module in my current infrastructure, I need to disable the sysctl configuration in the os_hardening module.
So, I added the "enable_sysctl_config" parameter.
Thanks.
David.