### PR TITLE
let os_hardening::sysctl make decisions about system_environment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,6 +143,8 @@
 #
 # @param enable_sysctl_config
 #
+# @param manage_container_network_sysctls
+#
 # @param system_umask
 #
 # @param shadow_group
@@ -217,6 +219,7 @@ class os_hardening (
   Optional[String]  $grub_password_hash                 = undef,
   Boolean           $boot_without_password              = true,
   Boolean           $enable_sysctl_config               = true,
+  Boolean           $manage_container_network_sysctls   = false,
   Optional[String]  $system_umask                       = undef,
   Optional[String]  $shadow_group                       = undef,
   Optional[String]  $shadow_mode                        = undef,
@@ -227,11 +230,14 @@ class os_hardening (
   # system environment configuration
   # there may be differences when using kvm/lxc vs metal
 
-  # sysctl configuration doesn't work in docker:
+  # Container sysctl management is opt-in because host-level settings cannot
+  # be managed safely from LXC and Docker.
   $configure_sysctl = (
-    $system_environment != 'lxc' and
-    $system_environment != 'docker' and
-    $enable_sysctl_config
+    $enable_sysctl_config and (
+      $system_environment != 'lxc' and
+      $system_environment != 'docker' or
+      $manage_container_network_sysctls
+    )
   )
 
   # Defaults for specific platforms
@@ -339,6 +345,7 @@ class os_hardening (
 
   if $configure_sysctl {
     class { 'os_hardening::sysctl':
+      system_environment      => $system_environment,
       enable_module_loading   => $enable_module_loading,
       load_modules            => $load_modules,
       cpu_vendor              => $cpu_vendor,

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -9,6 +9,8 @@
 #
 # Configures Kernel Parameters via sysctl
 #
+# @param system_environment
+#
 # @param enable_module_loading
 #
 # @param load_modules
@@ -44,6 +46,7 @@
 # @param enable_log_martians
 #
 class os_hardening::sysctl (
+  String  $system_environment      = 'default',
   Boolean $enable_module_loading   = true,
   Array   $load_modules            = [],
   String  $cpu_vendor              = 'intel',
@@ -200,68 +203,70 @@ class os_hardening::sysctl (
   sysctl { 'net.ipv4.conf.all.log_martians': value => String(bool2num($enable_log_martians)) }
   sysctl { 'net.ipv4.conf.default.log_martians': value => String(bool2num($enable_log_martians)) }
 
-  # System
-  # ------
+  if $system_environment != 'lxc' and $system_environment != 'docker' {
+    # System
+    # ------
 
-  # This settings controls how the kernel behaves towards module changes at runtime. Setting to 1 will disable module loading at runtime.
-  if $enable_module_loading == false {
-    sysctl { 'kernel.modules_disabled': value => '1' }
-  }
-  #kernel.modules_disabled = <%= @enable_module_loading ? 0 : 1 %>
+    # This settings controls how the kernel behaves towards module changes at runtime. Setting to 1 will disable module loading at runtime.
+    if $enable_module_loading == false {
+      sysctl { 'kernel.modules_disabled': value => '1' }
+    }
+    #kernel.modules_disabled = <%= @enable_module_loading ? 0 : 1 %>
 
-  # Magic Sysrq should be disabled, but can also be set to a safe value if so desired for physical machines. It can allow a safe reboot if
-  # the system hangs and is a 'cleaner' alternative to hitting the reset button.
-  # The following values are permitted:
-  #
-  # * **0** - disable sysrq
-  # * **1** - enable sysrq completely
-  # * **>1** - bitmask of enabled sysrq functions:
-  # * **2** - control of console logging level
-  # * **4** - control of keyboard (SAK, unraw)
-  # * **8** - debugging dumps of processes etc.
-  # * **16** - sync command
-  # * **32** - remount read-only
-  # * **64** - signalling of processes (term, kill, oom-kill)
-  # * **128** - reboot/poweroff
-  # * **256** - nicing of all RT tasks
-  if $enable_sysrq {
-    $limited_sysrq = String(4 + 16 + 32 + 64 + 128)
-    sysctl { 'kernel.sysrq': value => $limited_sysrq }
-  } else {
-    sysctl { 'kernel.sysrq': value => '0' }
-  }
+    # Magic Sysrq should be disabled, but can also be set to a safe value if so desired for physical machines. It can allow a safe reboot if
+    # the system hangs and is a 'cleaner' alternative to hitting the reset button.
+    # The following values are permitted:
+    #
+    # * **0** - disable sysrq
+    # * **1** - enable sysrq completely
+    # * **>1** - bitmask of enabled sysrq functions:
+    # * **2** - control of console logging level
+    # * **4** - control of keyboard (SAK, unraw)
+    # * **8** - debugging dumps of processes etc.
+    # * **16** - sync command
+    # * **32** - remount read-only
+    # * **64** - signalling of processes (term, kill, oom-kill)
+    # * **128** - reboot/poweroff
+    # * **256** - nicing of all RT tasks
+    if $enable_sysrq {
+      $limited_sysrq = String(4 + 16 + 32 + 64 + 128)
+      sysctl { 'kernel.sysrq': value => $limited_sysrq }
+    } else {
+      sysctl { 'kernel.sysrq': value => '0' }
+    }
 
-  # Enable stack protection by randomizing kernel va space
-  if $enable_stack_protection {
-    sysctl { 'kernel.randomize_va_space': value => '2' }
-  } else {
-    sysctl { 'kernel.randomize_va_space': value => '0' }
-  }
-  # Prevent core dumps with SUID. These are usually only needed by developers and may contain sensitive information.
-  sysctl { 'fs.suid_dumpable': value => String(bool2num($enable_core_dump)) }
+    # Enable stack protection by randomizing kernel va space
+    if $enable_stack_protection {
+      sysctl { 'kernel.randomize_va_space': value => '2' }
+    } else {
+      sysctl { 'kernel.randomize_va_space': value => '0' }
+    }
+    # Prevent core dumps with SUID. These are usually only needed by developers and may contain sensitive information.
+    sysctl { 'fs.suid_dumpable': value => String(bool2num($enable_core_dump)) }
 
-  # configure for module hardening
-  # if modules cannot be loaded at runtime, they must all
-  # be pre-configured in initramfs
-  if $enable_module_loading == false {
-    case $facts['os']['name'] {
-      'debian', 'ubuntu', 'cumuluslinux': {
-        file { '/etc/initramfs-tools/modules':
-          ensure  => file,
-          content => template('os_hardening/modules.erb'),
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0400',
-          notify  => Exec['update-initramfs'],
+    # configure for module hardening
+    # if modules cannot be loaded at runtime, they must all
+    # be pre-configured in initramfs
+    if $enable_module_loading == false {
+      case $facts['os']['name'] {
+        'debian', 'ubuntu', 'cumuluslinux': {
+          file { '/etc/initramfs-tools/modules':
+            ensure  => file,
+            content => template('os_hardening/modules.erb'),
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0400',
+            notify  => Exec['update-initramfs'],
+          }
+
+          exec { 'update-initramfs':
+            command     => '/usr/sbin/update-initramfs -u',
+            refreshonly => true,
+          }
         }
-
-        exec { 'update-initramfs':
-          command     => '/usr/sbin/update-initramfs -u',
-          refreshonly => true,
+        default: {
+          # TODO
         }
-      }
-      default: {
-        # TODO
       }
     }
   }

--- a/spec/classes/os_hardening_spec.rb
+++ b/spec/classes/os_hardening_spec.rb
@@ -6,6 +6,58 @@ describe 'os_hardening' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
+
+      context 'in an LXC container without network sysctl opt-in' do
+        let(:params) { { system_environment: 'lxc' } }
+
+        it { is_expected.not_to contain_class('os_hardening::sysctl') }
+      end
+
+      context 'in a Docker container without network sysctl opt-in' do
+        let(:params) { { system_environment: 'docker' } }
+
+        it { is_expected.not_to contain_class('os_hardening::sysctl') }
+      end
+
+      context 'in an LXC container with network sysctl opt-in' do
+        let(:params) do
+          {
+            system_environment: 'lxc',
+            manage_container_network_sysctls: true,
+          }
+        end
+
+        it do
+          is_expected.to contain_class('os_hardening::sysctl')
+            .with(system_environment: 'lxc')
+        end
+      end
+
+      context 'in a Docker container with network sysctl opt-in' do
+        let(:params) do
+          {
+            system_environment: 'docker',
+            manage_container_network_sysctls: true,
+          }
+        end
+
+        it do
+          is_expected.to contain_class('os_hardening::sysctl')
+            .with(system_environment: 'docker')
+        end
+      end
+
+      context 'with sysctl disabled and container network sysctl opt-in' do
+        let(:params) do
+          {
+            enable_sysctl_config: false,
+            system_environment: 'lxc',
+            manage_container_network_sysctls: true,
+          }
+        end
+
+        it { is_expected.not_to contain_class('os_hardening::sysctl') }
+      end
     end
   end
 end

--- a/spec/classes/sysctl_spec.rb
+++ b/spec/classes/sysctl_spec.rb
@@ -172,6 +172,48 @@ describe 'os_hardening::sysctl' do
           is_expected.to contain_sysctl('net.ipv4.icmp_ratelimit').with_value('10')
         end
       end
+
+      context 'in an opted-in LXC container' do
+        let(:params) do
+          {
+            system_environment: 'lxc',
+            enable_ipv6: true,
+            enable_module_loading: false,
+          }
+        end
+
+        it do
+          is_expected.to contain_sysctl('net.ipv4.ip_forward')
+          is_expected.to contain_sysctl('net.ipv6.conf.all.disable_ipv6')
+          is_expected.not_to contain_sysctl('kernel.sysrq')
+          is_expected.not_to contain_sysctl('kernel.randomize_va_space')
+          is_expected.not_to contain_sysctl('kernel.modules_disabled')
+          is_expected.not_to contain_sysctl('fs.suid_dumpable')
+          is_expected.not_to contain_file('/etc/initramfs-tools/modules')
+          is_expected.not_to contain_exec('update-initramfs')
+        end
+      end
+
+      context 'in an opted-in Docker container' do
+        let(:params) do
+          {
+            system_environment: 'docker',
+            enable_ipv6: true,
+            enable_module_loading: false,
+          }
+        end
+
+        it do
+          is_expected.to contain_sysctl('net.ipv4.ip_forward')
+          is_expected.to contain_sysctl('net.ipv6.conf.all.disable_ipv6')
+          is_expected.not_to contain_sysctl('kernel.sysrq')
+          is_expected.not_to contain_sysctl('kernel.randomize_va_space')
+          is_expected.not_to contain_sysctl('kernel.modules_disabled')
+          is_expected.not_to contain_sysctl('fs.suid_dumpable')
+          is_expected.not_to contain_file('/etc/initramfs-tools/modules')
+          is_expected.not_to contain_exec('update-initramfs')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Add explicit, opt-in sysctl management for LXC and Docker without changing the
upstream default.

- `manage_container_network_sysctls` defaults to `false`.
- LXC and Docker continue to omit `os_hardening::sysctl` unless callers opt in.
- Opted-in container catalogs manage only the existing `net.ipv4.*` and
  `net.ipv6.*` resources.
- Container catalogs exclude every `kernel.*` and `fs.*` sysctl, including
  `kernel.modules_disabled`.
- Container catalogs also exclude `/etc/initramfs-tools/modules` and
  `update-initramfs`.
- `enable_sysctl_config = false` always disables the sysctl class.

This replaces the original implementation and is rebased directly on the
current upstream `master`. The old Puppet 8 compatibility commits are not
included because upstream already contains the structured-fact migrations.

## Validation

- Puppet 8 parser validation
- Puppet syntax, lint, metadata, and unit tests: 449 examples
- Catalog coverage for default, metal, LXC, Docker, opt-in, and explicit disable
- Live Puppet 8 compilation and two successful feature-environment converges in
  an LXC container
- Live catalog inspection: 32 network sysctls and no kernel, filesystem, or
  initramfs resources
- No legacy `$::fact` references remain
