### PR TITLE
Add ignore_max_files_warnings (#279)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Otherwise puppet will drop an error (duplicate resource)!
   array of system user accounts that should _not be_ hardened (password disabled and shell set to `/usr/sbin/nologin`)
 * `folders_to_restrict = ['/usr/local/games','/usr/local/sbin','/usr/local/bin','/usr/bin','/usr/sbin','/sbin','/bin']`
   folders to make sure of that group and world do not have write access to it or any of the contents
+* `ignore_max_files_warnings = false`
+  true if you do not want puppet to log max_files and performance warnings on the recursion of folders with > 1000 files eg /bin /usr/bin
 * `recurselimit = 5`
   directory depth for recursive permission check
 * `passwdqc_enabled = true`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@ class os_hardening (
   Array             $ignore_files_in_folder_to_restrict = [],
   Array             $folders_to_restrict                =
     ['/usr/local/games','/usr/local/sbin','/usr/local/bin','/usr/bin','/usr/sbin','/sbin','/bin'],
+  Boolean           $ignore_max_files_warnings          = false,
   Array             $restrict_log_dir                   =
     ['/var/log/'],
   Integer           $recurselimit                       = 5,
@@ -177,6 +178,7 @@ class os_hardening (
     ignore_restrict_log_dir            => $ignore_restrict_log_dir,
     ignore_files_in_folder_to_restrict => $ignore_files_in_folder_to_restrict,
     folders_to_restrict                => $folders_to_restrict_int,
+    ignore_max_files_warnings          => $ignore_max_files_warnings,
     restrict_log_dir                   => $restrict_log_dir,
     shadowgroup                        => $shadowgroup,
     shadowmode                         => $shadowmode,

--- a/manifests/minimize_access.pp
+++ b/manifests/minimize_access.pp
@@ -11,6 +11,7 @@
 #
 class os_hardening::minimize_access (
   Boolean $allow_change_user                    = false,
+  Boolean $ignore_max_files_warnings            = false,
   Boolean $manage_home_permissions              = false,
   Boolean $manage_log_permissions               = false,
   Boolean $manage_cron_permissions              = false,
@@ -45,6 +46,15 @@ class os_hardening::minimize_access (
     }
   }
 
+  # Whether $folders_to_restrict should issue warnings if the puppet max_files
+  # file resource exceeds the default soft limit of 1000 on recursive file
+  # resources, /bin and /usr/bin can exceed this default limit
+  if $ignore_max_files_warnings {
+    $use_max_files = -1
+  } else {
+    $use_max_files = 0
+  }
+
   # remove write permissions from path folders ($PATH) for all regular users
   # this prevents changing any system-wide command from normal users
   ensure_resources ('file',
@@ -56,6 +66,7 @@ class os_hardening::minimize_access (
       recurse                 => true,
       recurselimit            => $recurselimit,
       selinux_ignore_defaults => true,
+      max_files               => $use_max_files,
     }
   })
 # Added users with homes


### PR DESCRIPTION
* Allow user to disable puppet warnings related to max_files exceeding default of 1000 if they choose to