### PR TITLE
Remove Puppet v5 support + tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - rvm: 2.4.5
-            puppet_gem_version: "~> 5.0"
           - rvm: 2.6
             puppet_gem_version: "~> 6.0"
     steps:
@@ -61,18 +59,10 @@ jobs:
       fail-fast: false
       matrix:
         version_os_puppet:
-          - centos-7-puppet5
           - centos-7-puppet6
-          - debian-8-puppet5
           - centos-8-puppet6
-          - debian-9-puppet5
           - debian-9-puppet6
-          - opensuse-42-puppet5
-          - oracle-6-puppet5
-          - oracle-7-puppet5
           - oracle-7-puppet6
-          - ubuntu-16-04-puppet5
-          - ubuntu-18-04-puppet5
           - ubuntu-18-04-puppet6
     steps:
     - uses: actions/checkout@v2

--- a/kitchen.do.yml
+++ b/kitchen.do.yml
@@ -13,12 +13,6 @@ provisioner:
   require_chef_for_busser: false
 
 platforms:
-  - name: centos-7-puppet5
-    driver_config:
-      image: centos-7-x64
-    provisioner:
-      puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-      puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
   - name: centos-7-puppet6
     driver_config:
       image: centos-7-x64
@@ -31,42 +25,12 @@ platforms:
     provisioner:
       puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-8.noarch.rpm
       puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet6/puppet6-release-el-8.noarch.rpm
-  - name: debian-8-puppet5
-    driver_config:
-      image: debian-8-x64
-    provisioner:
-      custom_pre_install_command: |
-        sudo apt-get -y install apt-transport-https
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-trusty.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-trusty.deb
-  - name: debian-9-puppet5
-    driver_config:
-      image: debian-9-x64
-    provisioner:
-      custom_pre_install_command: |
-        sudo apt-get -y install apt-transport-https
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-xenial.deb
   - name: debian-9-puppet6
     driver_config:
       image: debian-9-x64
     provisioner:
       puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
       puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet6-release-xenial.deb
-  - name: ubuntu-16-04-puppet5
-    driver_config:
-      image: ubuntu-16-04-x64
-    provisioner:
-      custom_pre_install_command: |
-        sudo apt-get -y install apt-transport-https
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-xenial.deb
-  - name: ubuntu-18-04-puppet5
-    driver_config:
-      image: ubuntu-18-04-x64
-    provisioner:
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-bionic.deb
   - name: ubuntu-18-04-puppet6
     driver_config:
       image: ubuntu-18-04-x64

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,10 +16,6 @@ provisioner:
   require_chef_for_busser: false
 
 platforms:
-  - name: centos-7-puppet5
-    provisioner:
-      puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-      puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
   - name: centos-7-puppet6
     provisioner:
       puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
@@ -28,38 +24,10 @@ platforms:
     provisioner:
       puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-8.noarch.rpm
       puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet6/puppet6-release-el-8.noarch.rpm
-  - name: debian-8-puppet5
-    provisioner:
-      custom_pre_install_command: |
-        sudo apt-get -y install apt-transport-https
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-trusty.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-trusty.deb
-  - name: debian-9-puppet5
-    provisioner:
-      custom_pre_install_command: |
-        sudo apt-get -y install apt-transport-https
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-xenial.deb
   - name: debian-9-puppet6
     provisioner:
       puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
       puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet6-release-xenial.deb
-  - name: opensuse-42-puppet5
-    driver_config:
-      image: opensuse/leap:42.3
-      platform: opensuse
-    provisioner:
-      custom_pre_install_command: |
-        sudo zypper addrepo -n puppet5 -f -G http://yum.puppetlabs.com/puppet5/sles/12/x86_64 puppet5
-        sudo http_proxy=<%= ENV['http_proxy'] %> https_proxy=<%= ENV['https_proxy'] %> zypper install -y puppet-agent kmod
-  - name: opensuse-15-puppet5
-    driver_config:
-      image: opensuse/leap:15
-      platform: opensuse
-    provisioner:
-      custom_pre_install_command: |
-        sudo zypper addrepo -n puppet5 -f -G http://yum.puppetlabs.com/puppet5/sles/12/x86_64 puppet5
-        sudo http_proxy=<%= ENV['http_proxy'] %> https_proxy=<%= ENV['https_proxy'] %> zypper install -y puppet-agent
   - name: opensuse-15-puppet6
     driver_config:
       image: opensuse/leap:15
@@ -68,20 +36,6 @@ platforms:
       custom_pre_install_command: |
         sudo zypper addrepo -n puppet6 -f -G http://yum.puppetlabs.com/puppet6/sles/12/x86_64 puppet6
         sudo http_proxy=<%= ENV['http_proxy'] %> https_proxy=<%= ENV['https_proxy'] %> zypper install -y puppet-agent
-  - name: oracle-6-puppet5
-    driver_config:
-      image: oraclelinux:6
-      platform: rhel
-    provisioner:
-      puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
-      puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet5/puppet5-release-el-6.noarch.rpm
-  - name: oracle-7-puppet5
-    driver_config:
-      image: oraclelinux:7
-      platform: rhel
-    provisioner:
-      puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-      puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm
   - name: oracle-7-puppet6
     driver_config:
       image: oraclelinux:7
@@ -89,20 +43,6 @@ platforms:
     provisioner:
       puppet_yum_repo: https://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
       puppet_yum_collections_repo: http://yum.puppetlabs.com/puppet6/puppet6-release-el-7.noarch.rpm
-  - name: ubuntu-16-04-puppet5
-    driver_config:
-      image: ubuntu:16.04
-    provisioner:
-      custom_pre_install_command: |
-        sudo apt-get -y install apt-transport-https
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-xenial.deb
-  - name: ubuntu-18-04-puppet5
-    driver_config:
-      image: ubuntu:18.04
-    provisioner:
-      puppet_apt_repo: https://apt.puppetlabs.com/puppetlabs-release-xenial.deb
-      puppet_apt_collections_repo: http://apt.puppetlabs.com/puppet5-release-bionic.deb
   - name: ubuntu-18-04-puppet6
     driver_config:
       image: ubuntu:18.04

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 7.0.0"
+      "version_requirement": ">= 4.6.0 < 8.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "template-url": "https://github.com/dev-sec/puppet-pdk-template#2.1.1",


### PR DESCRIPTION
As Puppet version 5 is EOL since beginning of this year and some features collide with our tests, support should be removed.