### PR TITLE
fix(pam_passwdqc): remove accidental paste from `pam_passwdqc.erb`

### DIFF
--- a/templates/pam_passwdqc.erb
+++ b/templates/pam_passwdqc.erb
@@ -1,5 +1,5 @@
 # MANAGED BY PUPPET
-passwdqc.erbName: passwdqc password strength enforcement
+Name: passwdqc password strength enforcement
 Default: yes
 Priority: 1024
 Conflicts: cracklib


### PR DESCRIPTION
Fixes #298 

Signed-off-by: Nils Ballmann <nils.ballmann.ext@siemens.com>