### PR TITLE
Add support to managing extra kernel flags

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,10 @@ class os_hardening (
 
   Optional[String]  $shadow_group                       = undef,
   Optional[String]  $shadow_mode                        = undef,
+
+  Boolean           $boot_without_password              = true,
+  Boolean           $enable_transparent_hugepage        = false,
+  String            $swappiness_value                   = '60',
 ) {
 
   # Prepare
@@ -217,23 +221,25 @@ class os_hardening (
 
   if $configure_sysctl {
     class { 'os_hardening::sysctl':
-      enable_module_loading   => $enable_module_loading,
-      load_modules            => $load_modules,
-      cpu_vendor              => $cpu_vendor,
-      icmp_ratelimit          => $icmp_ratelimit,
-      desktop_enabled         => $desktop_enabled,
-      enable_ipv4_forwarding  => $enable_ipv4_forwarding,
-      manage_ipv6             => $manage_ipv6,
-      enable_ipv6             => $enable_ipv6,
-      enable_ipv6_forwarding  => $enable_ipv6_forwarding,
-      arp_restricted          => $arp_restricted,
-      arp_ignore_samenet      => $arp_ignore_samenet,
-      enable_sysrq            => $enable_sysrq,
-      enable_core_dump        => $enable_core_dump,
-      enable_stack_protection => $enable_stack_protection,
-      enable_rpfilter         => $enable_rpfilter,
-      rpfilter_loose          => $rpfilter_loose,
-      enable_log_martians     => $enable_log_martians,
+      enable_module_loading    => $enable_module_loading,
+      load_modules             => $load_modules,
+      cpu_vendor               => $cpu_vendor,
+      icmp_ratelimit           => $icmp_ratelimit,
+      desktop_enabled          => $desktop_enabled,
+      enable_ipv4_forwarding   => $enable_ipv4_forwarding,
+      manage_ipv6              => $manage_ipv6,
+      enable_ipv6              => $enable_ipv6,
+      enable_ipv6_forwarding   => $enable_ipv6_forwarding,
+      arp_restricted           => $arp_restricted,
+      arp_ignore_samenet       => $arp_ignore_samenet,
+      enable_sysrq             => $enable_sysrq,
+      enable_core_dump         => $enable_core_dump,
+      enable_stack_protection  => $enable_stack_protection,
+      enable_rpfilter          => $enable_rpfilter,
+      rpfilter_loose           => $rpfilter_loose,
+      enable_log_martians      => $enable_log_martians,
+      enable_overcommit_memory => $enable_overcommit_memory,
+      swappiness_value         => $swappiness_value,
     }
   }
 
@@ -252,5 +258,9 @@ class os_hardening (
 
   class { 'os_hardening::umask':
     system_umask          => $system_umask,
+  }
+
+  class { 'os_hardening::kernel_options':
+    enable_transparent_hugepage  => $enable_transparent_hugepage,
   }
 }

--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -10,23 +10,25 @@
 # Configures Kernel Parameters via sysctl
 #
 class os_hardening::sysctl (
-  Boolean $enable_module_loading   = true,
-  Array   $load_modules            = [],
-  String  $cpu_vendor              = 'intel',
-  String  $icmp_ratelimit          = '100',
-  Boolean $desktop_enabled         = false,
-  Boolean $enable_ipv4_forwarding  = false,
-  Boolean $manage_ipv6             = true,
-  Boolean $enable_ipv6             = false,
-  Boolean $enable_ipv6_forwarding  = false,
-  Boolean $arp_restricted          = true,
-  Boolean $arp_ignore_samenet      = false,
-  Boolean $enable_sysrq            = false,
-  Boolean $enable_core_dump        = false,
-  Boolean $enable_stack_protection = true,
-  Boolean $enable_rpfilter         = true,
-  Boolean $rpfilter_loose          = false,
-  Boolean $enable_log_martians     = true,
+  Boolean $enable_module_loading    = true,
+  Array   $load_modules             = [],
+  String  $cpu_vendor               = 'intel',
+  String  $icmp_ratelimit           = '100',
+  Boolean $desktop_enabled          = false,
+  Boolean $enable_ipv4_forwarding   = false,
+  Boolean $manage_ipv6              = true,
+  Boolean $enable_ipv6              = false,
+  Boolean $enable_ipv6_forwarding   = false,
+  Boolean $arp_restricted           = true,
+  Boolean $arp_ignore_samenet       = false,
+  Boolean $enable_sysrq             = false,
+  Boolean $enable_core_dump         = false,
+  Boolean $enable_stack_protection  = true,
+  Boolean $enable_rpfilter          = true,
+  Boolean $rpfilter_loose           = false,
+  Boolean $enable_log_martians      = true,
+  Boolean $enable_overcommit_memory = true,
+  String  $swappiness_value         = '60',
 ) {
 
   # set variables
@@ -236,5 +238,15 @@ class os_hardening::sysctl (
     }
   }
 
+  # configure the memory overcommitment
+  # ** 0 ** - kernel attempts to estimate the amount of free memory left when userspace requests more memory.
+  # ** 1 ** - kernel pretends there is always enough memory until it actually runs out.
+  if $enable_overcommit_memory {
+    sysctl { 'vm.overcommit_memory': value => '1' }
+  } else {
+    sysctl { 'vm.overcommit_memory': value => '0' }
+  }
+
+  sysctl { 'vm.swappiness': value => String($swappiness_value) }
 }
 


### PR DESCRIPTION
Added support to managing extra kernel flags, specifically vm.swappiness, vm.overcommit_memory and transparent_hugepage.

- vm.swappiness and vm.overcommit_memory are supported by sysctl, so, the changes went into sysctl module
- transparent_hugepage isn't supported by sysctl, so, I created a module to handle kernel flags like this.

