### PR TITLE
Replace legacy architecture fact with structed fact os.architecture

### DIFF
--- a/manifests/sysctl.pp
+++ b/manifests/sysctl.pp
@@ -30,7 +30,7 @@ class os_hardening::sysctl (
 ) {
 
   # set variables
-  if $::architecture == 'amd64' or $::architecture == 'x86_64' {
+  if $facts['os']['architecture'] == 'amd64' or $facts['os']['architecture'] == 'x86_64' {
     $x86_64 = true
   } else {
     $x86_64 = false


### PR DESCRIPTION
The fact `$architecture` is deprecated.

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Unknown variable: '::architecture'.
```

This MR replaces it with the fact with `$facts['os']['architecture‘]`.